### PR TITLE
Fix a null pointer exception on non-cutout devices

### DIFF
--- a/FateGrandAutomata/CutoutManager.cs
+++ b/FateGrandAutomata/CutoutManager.cs
@@ -23,6 +23,8 @@ namespace FateGrandAutomata
                 return;
 
             var cutout = MainActivity.Window.DecorView.RootWindowInsets.DisplayCutout;
+            if (cutout == null)
+                return;
 
             var l = cutout.SafeInsetLeft;
             var t = cutout.SafeInsetTop;


### PR DESCRIPTION
It's a simple enough change, and after this it no longer errors out for my non-notched device.