### PR TITLE
Add foreground service permission

### DIFF
--- a/FateGrandAutomata/Properties/AndroidManifest.xml
+++ b/FateGrandAutomata/Properties/AndroidManifest.xml
@@ -6,4 +6,5 @@
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 </manifest>


### PR DESCRIPTION
This permission is required for some android sdk versions for foreground
notifcations to work.