### PR TITLE
Fix Autoskill selected item not displaying correctly

### DIFF
--- a/FateGrandAutomata/AutoSkill/AutoSkillActivity.cs
+++ b/FateGrandAutomata/AutoSkill/AutoSkillActivity.cs
@@ -88,17 +88,6 @@ namespace FateGrandAutomata
                 .PutStringSet(key, autoSkillItems)
                 .Commit();
 
-            // If first item, set as selected
-            key = GetString(Resource.String.pref_autoskill_selected);
-            var selectedAutoskill = prefs.GetString(key, "");
-            if (string.IsNullOrWhiteSpace(selectedAutoskill))
-            {
-                prefs
-                    .Edit()
-                    .PutString(key, guid)
-                    .Commit();
-            }
-
             EditItem(guid);
         }
     }

--- a/FateGrandAutomata/AutoSkill/AutoSkillSettingsFragment.cs
+++ b/FateGrandAutomata/AutoSkill/AutoSkillSettingsFragment.cs
@@ -96,23 +96,21 @@ namespace FateGrandAutomata
                 .PutStringSet(autoskillItemsKeys, autoskillItems)
                 .Commit();
 
-            UnselectItem(AutoskillItemKey, prefs, autoskillItems);
+            UnselectItem(AutoskillItemKey, prefs);
 
             // We opened a separate activity for autoskill item
             Activity.Finish();
         }
 
-        void UnselectItem(string AutoskillItemKey, ISharedPreferences Prefs, IReadOnlyCollection<string> AutoskillItems)
+        void UnselectItem(string AutoskillItemKey, ISharedPreferences Prefs)
         {
             var selectedAutoskillKey = GetString(Resource.String.pref_autoskill_selected);
             var selectedAutoSkill = Prefs.GetString(selectedAutoskillKey, "");
 
             if (selectedAutoSkill == AutoskillItemKey)
             {
-                selectedAutoSkill = AutoskillItems.Count > 0 ? AutoskillItems.First() : "";
-
                 Prefs.Edit()
-                    .PutString(selectedAutoskillKey, selectedAutoSkill)
+                    .Remove(selectedAutoskillKey)
                     .Commit();
             }
         }

--- a/FateGrandAutomata/AutoSkill/ManageAutoSkillSettingsFragment.cs
+++ b/FateGrandAutomata/AutoSkill/ManageAutoSkillSettingsFragment.cs
@@ -40,10 +40,10 @@ namespace FateGrandAutomata
                 list.SetEntryValues(entryValues);
                 list.SetEntries(entryLabels);
 
-                if (autoSkillItems.Count == 1)
-                {
-                    list.SetValueIndex(0);
-                }
+                key = GetString(Resource.String.pref_autoskill_selected);
+                var actual = prefManager.GetString(key, "");
+                list.Value = ""; // Force update
+                list.Value = actual;
             }
         }
 
@@ -55,8 +55,6 @@ namespace FateGrandAutomata
             {
                 manageAutoskill.PreferenceClick += (S, E) => StartActivity(new Intent(Activity, typeof(AutoSkillActivity)));
             }
-
-            Init();
         }
     }
 }


### PR DESCRIPTION
fixes #22 

## Old behaviour
- When a new autoskill config is created, if no config is selected, it is set as selected.
- When a config is deleted, if it is selected, some other config is set as selected (I thought that the first was being selected, but I was wrong).

## Problem
The selected autoskill control was not getting updated when we reach the screen using the back button.
If we navigate there from the main settings page, expected config was being shown as selected.

## New Behaviour
- The configs displayed in selected autoskill control are forcefully updated, even when reaching the screen by back button.
- No config will be selected automatically when the user adds or deletes configs.
- When the user deletes the selected config, the selected config will be unset.