### PR TITLE
Fix: Autosupport scrolling too far

### DIFF
--- a/FateGrandAutomata/AndroidImpl.cs
+++ b/FateGrandAutomata/AndroidImpl.cs
@@ -32,11 +32,13 @@ namespace FateGrandAutomata
 
             var swipePath = new Path();
             swipePath.MoveTo(Start.X, Start.Y);
-            swipePath.LineTo(End.X, End.Y);
-            
+
+            var center = new Location((Start.X + End.X) / 2, (Start.Y + End.Y) / 2);
+            swipePath.LineTo(center.X, center.Y);
+
             var gestureBuilder = new GestureDescription.Builder();
             gestureBuilder.AddStroke(new GestureDescription.StrokeDescription(swipePath, 0, duration));
-            
+
             PerformGesture(gestureBuilder.Build());
         }
 
@@ -59,28 +61,6 @@ namespace FateGrandAutomata
             gestureBuilder.AddStroke(new GestureDescription.StrokeDescription(swipePath, 0, duration));
 
             PerformGesture(gestureBuilder.Build());
-        }
-
-        class GestureCompletedCallback : AccessibilityService.GestureResultCallback
-        {
-            readonly ManualResetEventSlim _event;
-
-            public GestureCompletedCallback(ManualResetEventSlim Event)
-            {
-                _event = Event;
-            }
-
-            public override void OnCompleted(GestureDescription GestureDescription)
-            {
-                _event.Set();
-                base.OnCompleted(GestureDescription);
-            }
-
-            public override void OnCancelled(GestureDescription GestureDescription)
-            {
-                _event.Set();
-                base.OnCancelled(GestureDescription);
-            }
         }
 
         readonly ManualResetEventSlim _gestureWaitHandle = new ManualResetEventSlim();

--- a/FateGrandAutomata/AndroidImpl.cs
+++ b/FateGrandAutomata/AndroidImpl.cs
@@ -1,17 +1,14 @@
 ﻿using System;
 using System.IO;
-using System.Threading;
-using Android.AccessibilityServices;
 using Android.OS;
 using Android.Widget;
 using CoreAutomata;
 using Org.Opencv.Android;
 using Environment = Android.OS.Environment;
-using Path = Android.Graphics.Path;
 
 namespace FateGrandAutomata
 {
-    public class AndroidImpl : IPlatformImpl
+    public partial class AndroidImpl : IPlatformImpl
     {
         readonly ScriptRunnerService _accessibilityService;
 
@@ -26,78 +23,12 @@ namespace FateGrandAutomata
 
         public Region WindowRegion => CutoutManager.GetCutoutAppliedRegion(_accessibilityService);
 
-        public void Scroll(Location Start, Location End)
-        {
-            const int duration = 300;
-
-            var swipePath = new Path();
-            swipePath.MoveTo(Start.X, Start.Y);
-
-            var center = new Location((Start.X + End.X) / 2, (Start.Y + End.Y) / 2);
-            swipePath.LineTo(center.X, center.Y);
-
-            var gestureBuilder = new GestureDescription.Builder();
-            gestureBuilder.AddStroke(new GestureDescription.StrokeDescription(swipePath, 0, duration));
-
-            PerformGesture(gestureBuilder.Build());
-        }
-
         readonly Lazy<Handler> _handler = new Lazy<Handler>(() => new Handler(Looper.MainLooper));
 
         public void Toast(string Msg)
         {
             _handler.Value.Post(() =>
                 Android.Widget.Toast.MakeText(_accessibilityService, Msg, ToastLength.Short).Show());
-        }
-
-        public void Click(Location Location)
-        {
-            const int duration = 1;
-
-            var swipePath = new Path();
-            swipePath.MoveTo(Location.X, Location.Y);
-
-            var gestureBuilder = new GestureDescription.Builder();
-            gestureBuilder.AddStroke(new GestureDescription.StrokeDescription(swipePath, 0, duration));
-
-            PerformGesture(gestureBuilder.Build());
-        }
-
-        readonly ManualResetEventSlim _gestureWaitHandle = new ManualResetEventSlim();
-
-        void PerformGesture(GestureDescription Gesture, bool DoWait = true)
-        {
-            _gestureWaitHandle.Reset();
-
-            _accessibilityService.DispatchGesture(Gesture, new GestureCompletedCallback(_gestureWaitHandle), null);
-
-            if (DoWait)
-            {
-                AutomataApi.Wait(GestureWait);
-            }
-
-            _gestureWaitHandle.Wait();
-        }
-
-        const double GestureWait = 0.3;
-
-        public void ContinueClick(Location Location, int Times)
-        {
-            const int clickTime = 50;
-            const int clickDelay = 10;
-
-            while (Times-- > 0)
-            {
-                var swipePath = new Path();
-                swipePath.MoveTo(Location.X, Location.Y);
-
-                var stroke = new GestureDescription.StrokeDescription(swipePath, clickDelay, clickTime);
-
-                var gestureBuilder = new GestureDescription.Builder()
-                    .AddStroke(stroke);
-
-                PerformGesture(gestureBuilder.Build(), false);
-            }
         }
 
         public IPattern Screenshot()

--- a/FateGrandAutomata/AndroidImplGestures.cs
+++ b/FateGrandAutomata/AndroidImplGestures.cs
@@ -38,11 +38,11 @@ namespace FateGrandAutomata
             var holdPath = new Path();
             holdPath.MoveTo(End.X, End.Y);
 
-            swipeStroke.ContinueStroke(holdPath, 0, holdDuration, false);
+            var holdStroke = swipeStroke.ContinueStroke(holdPath, 0, holdDuration, false);
 
             var gestureBuilder = new GestureDescription.Builder();
             gestureBuilder.AddStroke(swipeStroke);
-
+            gestureBuilder.AddStroke(holdStroke);
             PerformGesture(gestureBuilder.Build());
         }
 

--- a/FateGrandAutomata/AndroidImplGestures.cs
+++ b/FateGrandAutomata/AndroidImplGestures.cs
@@ -1,13 +1,14 @@
 ﻿using System.Threading;
 using Android.AccessibilityServices;
 using Android.Graphics;
+using Android.OS;
 using CoreAutomata;
 
 namespace FateGrandAutomata
 {
     public partial class AndroidImpl
     {
-        public void Scroll(Location Start, Location End)
+        void ScrollAndroid7(Location Start, Location End)
         {
             const int duration = 300;
 
@@ -21,6 +22,37 @@ namespace FateGrandAutomata
             gestureBuilder.AddStroke(new GestureDescription.StrokeDescription(swipePath, 0, duration));
 
             PerformGesture(gestureBuilder.Build());
+        }
+
+        void ScrollAndroid8Plus(Location Start, Location End)
+        {
+            const int duration = 300;
+            const int holdDuration = 300;
+
+            var swipePath = new Path();
+            swipePath.MoveTo(Start.X, Start.Y);
+            swipePath.LineTo(End.X, End.Y);
+
+            var swipeStroke = new GestureDescription.StrokeDescription(swipePath, 0, duration, true);
+
+            var holdPath = new Path();
+            holdPath.MoveTo(End.X, End.Y);
+
+            swipeStroke.ContinueStroke(holdPath, 0, holdDuration, false);
+
+            var gestureBuilder = new GestureDescription.Builder();
+            gestureBuilder.AddStroke(swipeStroke);
+
+            PerformGesture(gestureBuilder.Build());
+        }
+
+        public void Scroll(Location Start, Location End)
+        {
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.O)
+            {
+                ScrollAndroid8Plus(Start, End);
+            }
+            else ScrollAndroid7(Start, End);
         }
 
         public void Click(Location Location)

--- a/FateGrandAutomata/AndroidImplGestures.cs
+++ b/FateGrandAutomata/AndroidImplGestures.cs
@@ -1,0 +1,76 @@
+﻿using System.Threading;
+using Android.AccessibilityServices;
+using Android.Graphics;
+using CoreAutomata;
+
+namespace FateGrandAutomata
+{
+    public partial class AndroidImpl
+    {
+        public void Scroll(Location Start, Location End)
+        {
+            const int duration = 300;
+
+            var swipePath = new Path();
+            swipePath.MoveTo(Start.X, Start.Y);
+
+            var center = new Location((Start.X + End.X) / 2, (Start.Y + End.Y) / 2);
+            swipePath.LineTo(center.X, center.Y);
+
+            var gestureBuilder = new GestureDescription.Builder();
+            gestureBuilder.AddStroke(new GestureDescription.StrokeDescription(swipePath, 0, duration));
+
+            PerformGesture(gestureBuilder.Build());
+        }
+
+        public void Click(Location Location)
+        {
+            const int duration = 1;
+
+            var swipePath = new Path();
+            swipePath.MoveTo(Location.X, Location.Y);
+
+            var gestureBuilder = new GestureDescription.Builder();
+            gestureBuilder.AddStroke(new GestureDescription.StrokeDescription(swipePath, 0, duration));
+
+            PerformGesture(gestureBuilder.Build());
+        }
+
+        readonly ManualResetEventSlim _gestureWaitHandle = new ManualResetEventSlim();
+
+        void PerformGesture(GestureDescription Gesture, bool DoWait = true)
+        {
+            _gestureWaitHandle.Reset();
+
+            _accessibilityService.DispatchGesture(Gesture, new GestureCompletedCallback(_gestureWaitHandle), null);
+
+            if (DoWait)
+            {
+                AutomataApi.Wait(GestureWait);
+            }
+
+            _gestureWaitHandle.Wait();
+        }
+
+        const double GestureWait = 0.3;
+
+        public void ContinueClick(Location Location, int Times)
+        {
+            const int clickTime = 50;
+            const int clickDelay = 10;
+
+            while (Times-- > 0)
+            {
+                var swipePath = new Path();
+                swipePath.MoveTo(Location.X, Location.Y);
+
+                var stroke = new GestureDescription.StrokeDescription(swipePath, clickDelay, clickTime);
+
+                var gestureBuilder = new GestureDescription.Builder()
+                    .AddStroke(stroke);
+
+                PerformGesture(gestureBuilder.Build(), false);
+            }
+        }
+    }
+}

--- a/FateGrandAutomata/AndroidImplGestures.cs
+++ b/FateGrandAutomata/AndroidImplGestures.cs
@@ -26,7 +26,9 @@ namespace FateGrandAutomata
                 gestureBuilder.AddStroke(swipeStroke);
 
                 // keep the "finger" pressed on the end position for a while
-                var holdStroke = swipeStroke.ContinueStroke(new Path(), swipeDuration, holdDuration, false);
+                var holdPath = new Path();
+                holdPath.MoveTo(End.X, End.Y);
+                var holdStroke = swipeStroke.ContinueStroke(holdPath, swipeDuration, holdDuration, false);
                 gestureBuilder.AddStroke(holdStroke);
             }
             else

--- a/FateGrandAutomata/AndroidImplGestures.cs
+++ b/FateGrandAutomata/AndroidImplGestures.cs
@@ -26,19 +26,19 @@ namespace FateGrandAutomata
 
         void ScrollAndroid8Plus(Location Start, Location End)
         {
-            const int duration = 300;
+            const int swipeDuration = 300;
             const int holdDuration = 300;
 
             var swipePath = new Path();
             swipePath.MoveTo(Start.X, Start.Y);
             swipePath.LineTo(End.X, End.Y);
 
-            var swipeStroke = new GestureDescription.StrokeDescription(swipePath, 0, duration, true);
+            var swipeStroke = new GestureDescription.StrokeDescription(swipePath, 0, swipeDuration, true);
 
             var holdPath = new Path();
             holdPath.MoveTo(End.X, End.Y);
 
-            var holdStroke = swipeStroke.ContinueStroke(holdPath, 0, holdDuration, false);
+            var holdStroke = swipeStroke.ContinueStroke(holdPath, swipeDuration, holdDuration, false);
 
             var gestureBuilder = new GestureDescription.Builder();
             gestureBuilder.AddStroke(swipeStroke);

--- a/FateGrandAutomata/FateGrandAutomata.csproj
+++ b/FateGrandAutomata/FateGrandAutomata.csproj
@@ -71,6 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AndroidImpl.cs" />
+    <Compile Include="AndroidImplGestures.cs" />
     <Compile Include="CardPriorityActivity.cs" />
     <Compile Include="AutoSkill\AutoSkillActivity.cs" />
     <Compile Include="AutoSkill\AutoSkillItemActivity.cs" />

--- a/FateGrandAutomata/FateGrandAutomata.csproj
+++ b/FateGrandAutomata/FateGrandAutomata.csproj
@@ -83,6 +83,7 @@
     <Compile Include="DraggableRecyclerView\ItemTouchHelperCallback.cs" />
     <Compile Include="DraggableRecyclerView\RecyclerListAdapter.cs" />
     <Compile Include="DroidCvPattern.cs" />
+    <Compile Include="GestureCompletedCallback.cs" />
     <Compile Include="Preferences\MainSettingsFragment.cs" />
     <Compile Include="ScriptRunnerService.cs" />
     <Compile Include="ImgListener.cs" />

--- a/FateGrandAutomata/GestureCompletedCallback.cs
+++ b/FateGrandAutomata/GestureCompletedCallback.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading;
+using Android.AccessibilityServices;
+
+namespace FateGrandAutomata
+{
+    class GestureCompletedCallback : AccessibilityService.GestureResultCallback
+    {
+        readonly ManualResetEventSlim _event;
+
+        public GestureCompletedCallback(ManualResetEventSlim Event)
+        {
+            _event = Event;
+        }
+
+        public override void OnCompleted(GestureDescription GestureDescription)
+        {
+            _event.Set();
+            base.OnCompleted(GestureDescription);
+        }
+
+        public override void OnCancelled(GestureDescription GestureDescription)
+        {
+            _event.Set();
+            base.OnCancelled(GestureDescription);
+        }
+    }
+}


### PR DESCRIPTION
fixes #31 

The scrolling can be controlled precisely if we hold the touch down after the swipe.
But, this feature was added only in Android 8.

So, for Android 7, I'm right now planning a simple fix where the distance to scroll is halved.
This is not exactly accurate but at least no servant/CE will be missed even if the play button is over the support bounds.
I'll see if I can come up with any better way for this.

On Android 8 and above, we can use the `continueStroke` function to do the swipe and hold gesture.