### PR TITLE
Performance Improvements

### DIFF
--- a/CoreAutomata/AutomataApi.cs
+++ b/CoreAutomata/AutomataApi.cs
@@ -162,6 +162,8 @@ namespace CoreAutomata
                 });
         }
 
+        public static IPattern GetResizableBlankPattern() => _platformImpl.GetResizableBlankPattern();
+
         public static void Toast(string Msg) => _platformImpl?.Toast(Msg);
 
         public static void ContinueClick(Location Location, int Times)

--- a/CoreAutomata/IPattern.cs
+++ b/CoreAutomata/IPattern.cs
@@ -7,6 +7,8 @@ namespace CoreAutomata
     {
         IPattern Resize(Size Size);
 
+        void Resize(IPattern Target, Size Size);
+
         bool IsMatch(IPattern Template, double Similarity);
 
         IEnumerable<Match> FindMatches(IPattern Template, double Similarity);

--- a/CoreAutomata/IPlatformImpl.cs
+++ b/CoreAutomata/IPlatformImpl.cs
@@ -18,6 +18,8 @@ namespace CoreAutomata
 
         IPattern LoadPattern(Stream Stream);
 
+        IPattern GetResizableBlankPattern();
+
         void MessageBox(string Title, string Message);
     }
 }

--- a/CoreAutomata/ScreenshotManager.cs
+++ b/CoreAutomata/ScreenshotManager.cs
@@ -12,13 +12,28 @@
         public static bool UsePreviousSnap { get; set; }
 
         static IPattern _previousPattern;
+        static IPattern _resizeTarget;
 
         static IPattern GetScaledScreenshot()
         {
-            return _platformImpl
-                .Screenshot()
-                .Crop(GameAreaManager.GameArea)
-                .Transform();
+            var sshot = _platformImpl.Screenshot()
+                .Crop(GameAreaManager.GameArea);
+
+            var scale = TransformationExtensions.ScreenToImageScale();
+
+            if (scale != null)
+            {
+                if (_resizeTarget == null)
+                {
+                    _resizeTarget = AutomataApi.GetResizableBlankPattern();
+                }
+
+                sshot.Resize(_resizeTarget, new Size(sshot.Width, sshot.Height) * scale.Value);
+
+                return _resizeTarget;
+            }
+
+            return sshot;
         }
 
         public static void Snapshot()

--- a/CoreAutomata/TransformationExtensions.cs
+++ b/CoreAutomata/TransformationExtensions.cs
@@ -2,7 +2,7 @@
 {
     static class TransformationExtensions
     {
-        static double? ScreenToImageScale()
+        public static double? ScreenToImageScale()
         {
             var targetDimensions = GameAreaManager.CompareDimension ?? GameAreaManager.ScriptDimension;
 
@@ -29,15 +29,6 @@
             }
 
             return targetDimensions.Pixels / (double) gameArea.H;
-        }
-
-        public static IPattern Transform(this IPattern Pattern)
-        {
-            var scale = ScreenToImageScale();
-
-            return scale == null
-                ? Pattern
-                : Pattern.Resize(new Size(Pattern.Width, Pattern.Height) * scale.Value);
         }
 
         public static Location Transform(this Location Location)

--- a/FateGrandAutomata/AndroidImpl.cs
+++ b/FateGrandAutomata/AndroidImpl.cs
@@ -43,6 +43,11 @@ namespace FateGrandAutomata
             return new DroidCvPattern(Stream);
         }
 
+        public IPattern GetResizableBlankPattern()
+        {
+            return new DroidCvPattern();
+        }
+
         public void MessageBox(string Title, string Message)
         {
             _handler.Value.Post(() =>

--- a/FateGrandAutomata/DisposableMat.cs
+++ b/FateGrandAutomata/DisposableMat.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Org.Opencv.Core;
+
+namespace FateGrandAutomata
+{
+    class DisposableMat : IDisposable
+    {
+        public Mat Mat { get; private set; }
+
+        public DisposableMat() : this(new Mat()) { }
+        
+        public DisposableMat(Mat Mat)
+        {
+            this.Mat = Mat;
+        }
+
+        public void Dispose()
+        {
+            Mat.Release();
+            Mat = null;
+        }
+    }
+}

--- a/FateGrandAutomata/DroidCvPattern.cs
+++ b/FateGrandAutomata/DroidCvPattern.cs
@@ -15,6 +15,8 @@ namespace FateGrandAutomata
     {
         readonly bool _ownsMat = true;
 
+        public DroidCvPattern() : this(new Mat()) { }
+
         public DroidCvPattern(Mat Mat, bool OwnsMat = true)
         {
             this.Mat = Mat;
@@ -46,9 +48,22 @@ namespace FateGrandAutomata
         {
             var result = new Mat();
 
-            Imgproc.Resize(Mat, result, new Org.Opencv.Core.Size(Size.Width, Size.Height), 0, 0, Imgproc.InterArea);
+            Resize(result, Size);
 
             return new DroidCvPattern(result);
+        }
+
+        void Resize(Mat Target, Size Size)
+        {
+            Imgproc.Resize(Mat, Target, new Org.Opencv.Core.Size(Size.Width, Size.Height), 0, 0, Imgproc.InterArea);
+        }
+
+        public void Resize(IPattern Target, Size Size)
+        {
+            if (Target is DroidCvPattern target)
+            {
+                Resize(target.Mat, Size);
+            }
         }
 
         public IPattern Crop(Region Region)

--- a/FateGrandAutomata/DroidCvPattern.cs
+++ b/FateGrandAutomata/DroidCvPattern.cs
@@ -92,11 +92,11 @@ namespace FateGrandAutomata
 
         public bool IsMatch(IPattern Template, double Similarity)
         {
-            using var result = new Mat();
+            using var result = new DisposableMat();
 
-            Imgproc.MatchTemplate(Mat, (Template as DroidCvPattern)?.Mat, result, Imgproc.TmCcoeffNormed);
+            Imgproc.MatchTemplate(Mat, (Template as DroidCvPattern)?.Mat, result.Mat, Imgproc.TmCcoeffNormed);
 
-            using var minMaxLocResult = Core.MinMaxLoc(result);
+            using var minMaxLocResult = Core.MinMaxLoc(result.Mat);
 
             return minMaxLocResult.MaxVal >= Similarity;
         }
@@ -107,16 +107,16 @@ namespace FateGrandAutomata
 
         public IEnumerable<Match> FindMatches(IPattern Template, double Similarity)
         {
-            using var result = new Mat();
+            using var result = new DisposableMat();
 
             // max is used for tmccoeff
-            Imgproc.MatchTemplate(Mat, (Template as DroidCvPattern)?.Mat, result, Imgproc.TmCcoeffNormed);
+            Imgproc.MatchTemplate(Mat, (Template as DroidCvPattern)?.Mat, result.Mat, Imgproc.TmCcoeffNormed);
 
-            Imgproc.Threshold(result, result, 0.1, 1, Imgproc.ThreshTozero);
+            Imgproc.Threshold(result.Mat, result.Mat, 0.1, 1, Imgproc.ThreshTozero);
 
             while (true)
             {
-                using var minMaxLocResult = Core.MinMaxLoc(result);
+                using var minMaxLocResult = Core.MinMaxLoc(result.Mat);
                 var score = minMaxLocResult.MaxVal;
 
                 if (score >= Similarity)
@@ -126,10 +126,10 @@ namespace FateGrandAutomata
 
                     yield return new Match(region, score);
 
-                    using var mask = new Mat();
+                    using var mask = new DisposableMat();
                     // Flood fill eliminates the problem of nearby points to a high similarity point also having high similarity
                     const double floodFillDiff = 0.05;
-                    Imgproc.FloodFill(result, mask, loc, new Scalar(0),
+                    Imgproc.FloodFill(result.Mat, mask.Mat, loc, new Scalar(0),
                         new Rect(),
                         new Scalar(floodFillDiff), new Scalar(floodFillDiff),
                         0);

--- a/FateGrandAutomata/DroidCvPattern.cs
+++ b/FateGrandAutomata/DroidCvPattern.cs
@@ -31,7 +31,7 @@ namespace FateGrandAutomata
 
             using var raw = new MatOfByte(buffer);
 
-            Mat = Imgcodecs.Imdecode(raw, Imgcodecs.CvLoadImageColor);
+            Mat = Imgcodecs.Imdecode(raw, Imgcodecs.CvLoadImageGrayscale);
         }
 
         public Mat Mat { get; }

--- a/FateGrandAutomata/FateGrandAutomata.csproj
+++ b/FateGrandAutomata/FateGrandAutomata.csproj
@@ -77,6 +77,7 @@
     <Compile Include="AutoSkill\AutoSkillItemActivity.cs" />
     <Compile Include="AutoSkill\MultiSelectListSummaryProvider.cs" />
     <Compile Include="CutoutManager.cs" />
+    <Compile Include="DisposableMat.cs" />
     <Compile Include="DraggableRecyclerView\ItemViewHolder.cs" />
     <Compile Include="DraggableRecyclerView\IItemTouchHelperAdapter.cs" />
     <Compile Include="DraggableRecyclerView\IItemTouchHelperViewHolder.cs" />

--- a/FateGrandAutomata/ImgListener.cs
+++ b/FateGrandAutomata/ImgListener.cs
@@ -94,6 +94,7 @@ namespace FateGrandAutomata
                 : _readBitmap;
 
             Org.Opencv.Android.Utils.BitmapToMat(correctedBitmap, _convertedMat);
+            correctedBitmap.Recycle();
 
             Imgproc.CvtColor(_convertedMat, _colorCorrectedMat, Imgproc.ColorRgba2gray);
 

--- a/FateGrandAutomata/ImgListener.cs
+++ b/FateGrandAutomata/ImgListener.cs
@@ -87,14 +87,16 @@ namespace FateGrandAutomata
                 _readBitmap = Bitmap.CreateBitmap(width + rowPadding / pixelStride, height, Bitmap.Config.Argb8888);
             }
 
-            _readBitmap.CopyPixelsFromBuffer(buffer); 
+            _readBitmap.CopyPixelsFromBuffer(buffer);
 
-            var correctedBitmap = _cropRequired
-                ? Bitmap.CreateBitmap(_readBitmap, 0, 0, width, height)
-                : _readBitmap;
-
-            Org.Opencv.Android.Utils.BitmapToMat(correctedBitmap, _convertedMat);
-            correctedBitmap.Recycle();
+            if (_cropRequired)
+            {
+                var correctedBitmap = Bitmap.CreateBitmap(_readBitmap, 0, 0, width, height);
+                Org.Opencv.Android.Utils.BitmapToMat(correctedBitmap, _convertedMat);
+                // if a new Bitmap was created, we need to tell the Garbage Collector to delete it immediately
+                correctedBitmap.Recycle();
+            }
+            else Org.Opencv.Android.Utils.BitmapToMat(_readBitmap, _convertedMat);
 
             Imgproc.CvtColor(_convertedMat, _colorCorrectedMat, Imgproc.ColorRgba2gray);
 

--- a/FateGrandAutomata/ImgListener.cs
+++ b/FateGrandAutomata/ImgListener.cs
@@ -95,7 +95,7 @@ namespace FateGrandAutomata
 
             Org.Opencv.Android.Utils.BitmapToMat(correctedBitmap, _convertedMat);
 
-            Imgproc.CvtColor(_convertedMat, _colorCorrectedMat, Imgproc.ColorRgba2bgr);
+            Imgproc.CvtColor(_convertedMat, _colorCorrectedMat, Imgproc.ColorRgba2gray);
 
             return new DroidCvPattern(_colorCorrectedMat, false);
         }

--- a/FateGrandAutomata/Properties/AndroidManifest.xml
+++ b/FateGrandAutomata/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="8" android:versionName="v0.8.0" package="com.mathewsachin.fategrandautomata" android:installLocation="auto" android:largeHeap="true">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="8" android:versionName="v0.8.0" package="com.mathewsachin.fategrandautomata" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="24" android:targetSdkVersion="28" />
 	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true" android:theme="@style/AppTheme"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/FateGrandAutomata/Properties/AndroidManifest.xml
+++ b/FateGrandAutomata/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="8" android:versionName="v0.8.0" package="com.mathewsachin.fategrandautomata" android:installLocation="auto">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="8" android:versionName="v0.8.0" package="com.mathewsachin.fategrandautomata" android:installLocation="auto" android:largeHeap="true">
 	<uses-sdk android:minSdkVersion="24" android:targetSdkVersion="28" />
 	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true" android:theme="@style/AppTheme"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />


### PR DESCRIPTION
1. Reuse `Mat` objects when resizing screenshots.
2. Use grayscale for matching
3. Correctly dispose intermediate `Mat`s used for image matching.
4. Recycle cropping bitmaps