### PR TITLE
Add Issue templates and Samsung troubleshooting doc

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+> MAKE SURE YOU TESTED THE LATEST RELEASE.
+
+> See 'SAMSUNG.md' first, if you're a Samsung user.
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+Include steps to reproduce the error if required
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+If an error occurred, you can find the message by expanding the app's notification.
+It is recommended that you atleast add one screenshot of FGO running on your device.
+
+**Device Info (please fill atleast 'Device model'):**
+ - Device model: [e.g. Xiaomi Redmi 4]
+ - Screen size: [e.g. 1280x720]
+ - Android Version: [e.g. Android 7.1]
+ - RAM: [e.g. 3GB]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,8 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,9 @@
+---
+name: Question
+about: For asking questions or discussions
+title: ''
+labels: question
+assignees: ''
+
+---
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Also, includes a UI for configuring Settings.
 
 **Needs Android 7 or later**
 
+See [Running on Samsung devices](SAMSUNG.md) if you're facing problems running the script on your Samsung devices.
+
 ## Why make another?
 Fate/Grand Order is all about farming.
 We already have an awesome auto battle script named [Fate-Grand-Order_Lua][FGOLua] which uses [AnkuLua](https://ankulua.boards.net/) (an implementation of [Sikuli](http://doc.sikuli.org/sikuli-script-index.html) using Lua language for scripting on Android).

--- a/SAMSUNG.md
+++ b/SAMSUNG.md
@@ -1,2 +1,6 @@
 # Running on Samsung devices
 
+If the script's not working correctly on your Samsung phone, like missing touches or not doing anything at all, follow these steps:
+
+- Make sure you're running F/GO with Full screen mode ON in Samsung's settings. Blue-bars should be shown in the space which is not used by FGO. If you did this wrong, that area would be black.
+- Go to `More options` in the app and turn ON `Ignore Notch calculation`.

--- a/SAMSUNG.md
+++ b/SAMSUNG.md
@@ -1,0 +1,2 @@
+# Running on Samsung devices
+


### PR DESCRIPTION
We should merge this only after the next release.
Also, after we've confirmed that the app doesn't crash on Samsung phones.