### PR TITLE
Click lower for starting a quest

### DIFF
--- a/FateGrandAutomata.Core/Modules/Game.cs
+++ b/FateGrandAutomata.Core/Modules/Game.cs
@@ -13,7 +13,7 @@ namespace FateGrandAutomata
         public static Region ContinueRegion { get; } = new Region(1400, 1000, 600, 200);
         public static Region MenuStorySkipRegion { get; } = new Region(2240, 20, 300, 120);
 
-        public static Location MenuSelectQuestClick { get; } = new Location(1900, 400);
+        public static Location MenuSelectQuestClick { get; } = new Location(1900, 440);
         public static Location MenuStartQuestClick { get; } = new Location(2400, 1350);
         public static Location ContinueClick { get; } = new Location(1650, 1120);
         public static Location MenuStorySkipClick { get; } = new Location(2360, 80);


### PR DESCRIPTION
This should work both with situations where there's only 1 quest and situations where the list is scrolled. The blue dot is the changed Y position.

![image](https://user-images.githubusercontent.com/12360257/80030433-78ab6900-84e8-11ea-8001-f0429cb3ee88.png)
![image](https://user-images.githubusercontent.com/12360257/80029828-a0e69800-84e7-11ea-89ac-a1284843625c.png)
