### PR TITLE
Wait for Support list to load

### DIFF
--- a/FateGrandAutomata.Core/Modules/Support.cs
+++ b/FateGrandAutomata.Core/Modules/Support.cs
@@ -55,10 +55,23 @@ namespace FateGrandAutomata
             }
         }
 
+        void EnsureSupportListHasLoaded()
+        {
+            // If the support list has loaded, 'Confirm Support Setup' button should be present.
+            var regionAnchor = ImageLocator.SupportRegionTool;
+            var regionAnchorLocation = new Region(2140, 328, 260, 312);
+            
+            // Give at max 30s for support servant list to load
+            const int timeout = 30; 
+            AutomataApi.Exists(regionAnchorLocation, regionAnchor, timeout);
+        }
+
         public bool SelectSupport(SupportSelectionMode SelectionMode)
         {
             var pattern = ImageLocator.SupportScreen;
             while (!Game.SupportScreenRegion.Exists(pattern)) { }
+
+            EnsureSupportListHasLoaded();
 
             switch (SelectionMode)
             {


### PR DESCRIPTION
Wait for support list to load before starting support selection code.
The `Confirm Support Setup` for the first servant is checked with a timeout of 30s.
This should be enough time for the list to load even with poor network connectivity or laggy device.

Here's the region checked:
![ensure_support](https://user-images.githubusercontent.com/10654537/80093987-16537680-8583-11ea-90f4-225161378a2c.png)
