### PR TITLE
Reduce standby memory consumption

### DIFF
--- a/CoreAutomata/Location.cs
+++ b/CoreAutomata/Location.cs
@@ -1,11 +1,9 @@
 ﻿namespace CoreAutomata
 {
-    public class Location
+    public struct Location
     {
-        public int X { get; set; }
-        public int Y { get; set; }
-
-        public Location() { }
+        public int X { get; }
+        public int Y { get; }
 
         public Location(int X, int Y)
         {

--- a/CoreAutomata/Location.cs
+++ b/CoreAutomata/Location.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace CoreAutomata
+﻿namespace CoreAutomata
 {
     public class Location
     {

--- a/CoreAutomata/ScreenshotManager.cs
+++ b/CoreAutomata/ScreenshotManager.cs
@@ -51,5 +51,14 @@
 
             return _previousPattern = GetScaledScreenshot();
         }
+
+        public static void ReleaseMemory()
+        {
+            _previousPattern?.Dispose();
+            _previousPattern = null;
+
+            _resizeTarget?.Dispose();
+            _resizeTarget = null;
+        }
     }
 }

--- a/CoreAutomata/Size.cs
+++ b/CoreAutomata/Size.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace CoreAutomata
+﻿namespace CoreAutomata
 {
     public struct Size
     {

--- a/FateGrandAutomata.Core/ImageLocator.cs
+++ b/FateGrandAutomata.Core/ImageLocator.cs
@@ -16,6 +16,16 @@ namespace FateGrandAutomata
                 : null;
         }
 
+        public static void ClearCache()
+        {
+            foreach (var pattern in RegionCachedPatterns.Values)
+            {
+                pattern.Dispose();
+            }
+
+            RegionCachedPatterns.Clear();
+        }
+
         static void SupportImgExtractor(string FolderName)
         {
             var resNamespace = $"{nameof(FateGrandAutomata)}.images.Support.{FolderName}";
@@ -140,12 +150,7 @@ namespace FateGrandAutomata
             // Reload Patterns on Server change
             if (_currentGameServer != server)
             {
-                foreach (var pattern in RegionCachedPatterns.Values)
-                {
-                    pattern.Dispose();
-                }
-
-                RegionCachedPatterns.Clear();
+                ClearCache();
 
                 _currentGameServer = server;
             }

--- a/FateGrandAutomata.Core/ImageLocator.cs
+++ b/FateGrandAutomata.Core/ImageLocator.cs
@@ -24,6 +24,8 @@ namespace FateGrandAutomata
             }
 
             RegionCachedPatterns.Clear();
+
+            ClearSupportCache();
         }
 
         static void SupportImgExtractor(string FolderName)
@@ -215,19 +217,37 @@ namespace FateGrandAutomata
 
         public static IPattern PresentBoxFull => GetRegionPattern("StopGifts.png");
 
+        static readonly Dictionary<string, IPattern> SupportCachedPatterns = new Dictionary<string, IPattern>();
+
+        public static void ClearSupportCache()
+        {
+            foreach (var pattern in SupportCachedPatterns.Values)
+            {
+                pattern.Dispose();
+            }
+
+            SupportCachedPatterns.Clear();
+        }
+
         public static IPattern LoadSupportImagePattern(string FileName)
         {
-            var stream = FileLoader(FileName);
-
-            if (stream == null)
+            if (!SupportCachedPatterns.ContainsKey(FileName))
             {
-                throw new ScriptExitException($"Unable to load image: {FileName}. Put images in {SupportImgFolder} folder");
+                var stream = FileLoader(FileName);
+
+                if (stream == null)
+                {
+                    throw new ScriptExitException(
+                        $"Unable to load image: {FileName}. Put images in {SupportImgFolder} folder");
+                }
+
+                using (stream)
+                {
+                    SupportCachedPatterns.Add(FileName, AutomataApi.LoadPattern(stream));
+                }
             }
 
-            using (stream)
-            {
-                return AutomataApi.LoadPattern(stream);
-            }
+            return SupportCachedPatterns[FileName];
         }
     }
 }

--- a/FateGrandAutomata.Core/Modules/Support.cs
+++ b/FateGrandAutomata.Core/Modules/Support.cs
@@ -261,7 +261,8 @@ namespace FateGrandAutomata
         {
             foreach (var friendName in _friendNameArray)
             {
-                using var pattern = ImageLocator.LoadSupportImagePattern(friendName);
+                // Cached pattern. Don't dipose here.
+                var pattern = ImageLocator.LoadSupportImagePattern(friendName);
 
                 foreach (var theFriend in AutomataApi.FindAll(Game.SupportFriendsRegion, pattern))
                 {
@@ -276,7 +277,8 @@ namespace FateGrandAutomata
         {
             foreach (var preferredServant in _preferredServantArray)
             {
-                using var pattern = ImageLocator.LoadSupportImagePattern(preferredServant);
+                // Cached pattern. Don't dipose here.
+                var pattern = ImageLocator.LoadSupportImagePattern(preferredServant);
 
                 foreach (var servant in AutomataApi.FindAll(Game.SupportListRegion, pattern))
                 {
@@ -289,7 +291,8 @@ namespace FateGrandAutomata
         {
             foreach (var preferredCraftEssence in _preferredCraftEssenceTable)
             {
-                using var pattern = ImageLocator.LoadSupportImagePattern(preferredCraftEssence.Name);
+                // Cached pattern. Don't dipose here.
+                var pattern = ImageLocator.LoadSupportImagePattern(preferredCraftEssence.Name);
 
                 var craftEssences = AutomataApi.FindAll(SearchRegion, pattern);
 

--- a/FateGrandAutomata.Core/SupportImageMaker.cs
+++ b/FateGrandAutomata.Core/SupportImageMaker.cs
@@ -40,7 +40,7 @@ namespace FateGrandAutomata
                 if (!screenBounds.Contains(supportBound))
                     continue;
 
-                var pattern = supportBound.GetPattern();
+                using var pattern = supportBound.GetPattern();
 
                 var servant = pattern.Crop(new Region(0, 0, 125, 44));
                 servant.Save(Path.Combine(ImageLocator.SupportServantImgFolder, $"{timestamp}_servant{i}.png"));

--- a/FateGrandAutomata/AndroidImplGestures.cs
+++ b/FateGrandAutomata/AndroidImplGestures.cs
@@ -1,7 +1,6 @@
 ﻿using System.Threading;
 using Android.AccessibilityServices;
 using Android.Graphics;
-using Android.OS;
 using CoreAutomata;
 
 namespace FateGrandAutomata

--- a/FateGrandAutomata/DroidCvPattern.cs
+++ b/FateGrandAutomata/DroidCvPattern.cs
@@ -29,9 +29,9 @@ namespace FateGrandAutomata
             using var ms = new MemoryStream(buffer);
             Stream.CopyTo(ms);
 
-            using var raw = new MatOfByte(buffer);
+            using var raw = new DisposableMat(new MatOfByte(buffer));
 
-            Mat = Imgcodecs.Imdecode(raw, Imgcodecs.CvLoadImageGrayscale);
+            Mat = Imgcodecs.Imdecode(raw.Mat, Imgcodecs.CvLoadImageGrayscale);
         }
 
         public Mat Mat { get; }

--- a/FateGrandAutomata/ImgListener.cs
+++ b/FateGrandAutomata/ImgListener.cs
@@ -12,11 +12,40 @@ namespace FateGrandAutomata
 
         IPattern _lastestPattern;
         bool _newImgAvailable;
-        readonly ImageReader _imageReader;
+        ImageReader _imageReader;
+
+        Mat _convertedMat,
+            _colorCorrectedMat;
+
+        Bitmap _readBitmap;
+        bool _cropRequired;
 
         public ImgListener(ImageReader ImageReader)
         {
             _imageReader = ImageReader;
+            _convertedMat = new Mat();
+            _colorCorrectedMat = new Mat();
+        }
+
+        protected override void Dispose(bool Disposing)
+        {
+            if (Disposing)
+            {
+                _convertedMat.Release();
+                _colorCorrectedMat.Release();
+
+                _convertedMat = _colorCorrectedMat = null;
+
+                _lastestPattern?.Dispose();
+                _lastestPattern = null;
+
+                _readBitmap?.Recycle();
+                _readBitmap = null;
+
+                _imageReader = null;
+            }
+
+            base.Dispose(Disposing);
         }
 
         public void OnImageAvailable(ImageReader Reader)
@@ -61,12 +90,6 @@ namespace FateGrandAutomata
 
             return _lastestPattern;
         }
-
-        readonly Mat _convertedMat = new Mat(),
-            _colorCorrectedMat = new Mat();
-
-        Bitmap _readBitmap;
-        bool _cropRequired;
 
         IPattern MatFromImage(Image Image)
         {

--- a/FateGrandAutomata/ScriptRunnerService.cs
+++ b/FateGrandAutomata/ScriptRunnerService.cs
@@ -68,6 +68,10 @@ namespace FateGrandAutomata
                 _mediaProjection = MediaProjectionManager.GetMediaProjection((int)Result.Ok, MediaProjectionToken);
             }
 
+            _imageReader = ImageReader.NewInstance(_screenWidth, _screenHeight, (ImageFormatType)1, 2);
+            _imgListener = new ImgListener(_imageReader);
+            _imageReader.SetOnImageAvailableListener(_imgListener, null);
+
             SetupVirtualDisplay();
 
             _windowManager.AddView(_layout, _layoutParams);
@@ -90,8 +94,17 @@ namespace FateGrandAutomata
             _virtualDisplay?.Release();
             _virtualDisplay = null;
 
+            _imgListener?.Dispose();
+            _imgListener = null;
+
+            _imageReader?.Close();
+            _imageReader = null;
+
             _mediaProjection?.Stop();
             _mediaProjection = null;
+
+            ScreenshotManager.ReleaseMemory();
+            ImageLocator.ClearCache();
 
             _windowManager.RemoveView(_layout);
             ServiceStarted = false;
@@ -237,10 +250,6 @@ namespace FateGrandAutomata
             }
 
             _layoutParams.Y = _screenWidth;
-
-            _imageReader = ImageReader.NewInstance(_screenWidth, _screenHeight, (ImageFormatType)1, 2);
-            _imgListener = new ImgListener(_imageReader);
-            _imageReader.SetOnImageAvailableListener(_imgListener, null);
         }
 
         (int X, int Y) GetMaxBtnCoordinates()

--- a/FateGrandAutomata/ScriptRunnerService.cs
+++ b/FateGrandAutomata/ScriptRunnerService.cs
@@ -129,6 +129,8 @@ namespace FateGrandAutomata
                 SetScriptControlBtnIcon(Resource.Drawable.ic_play);
             });
 
+            ImageLocator.ClearSupportCache();
+
             _entryPoint = null;
 
             _scriptStarted = false;


### PR DESCRIPTION
Reduce memory consumption of the app when you're not using it and only the AccessibilityService is running in the background.

When the service is stopped using the `Toggle Service` button:
1. `_previousPattern` and `_resizeTarget` in `ScreenshotManager` are released.
2. Cached server region-based images are cleared.
3. `ImageReader` is closed.
4. `Bitmap`s and `Mat`s used in `ImgListener` are released.

Also, introduces caching of support Servant/CE images.
This cache is cleared when the script is stopped.