### PR TITLE
Add Boost Item Selection Mode: Skip

### DIFF
--- a/FateGrandAutomata.Core/AutoBattle.cs
+++ b/FateGrandAutomata.Core/AutoBattle.cs
@@ -84,7 +84,11 @@ namespace FateGrandAutomata
 
             AutomataApi.Wait(2);
 
-            Game.MenuBoostItemClickArray[Preferences.Instance.BoostItemSelectionMode].Click();
+            var boostItem = Preferences.Instance.BoostItemSelectionMode;
+            if (boostItem >= 0)
+            {
+                Game.MenuBoostItemClickArray[boostItem].Click();
+            }
 
             // in case you run out of items
             Game.MenuBoostItemSkipClick.Click();

--- a/FateGrandAutomata.Core/Preferences/IFgoPreferences.cs
+++ b/FateGrandAutomata.Core/Preferences/IFgoPreferences.cs
@@ -29,7 +29,7 @@
         bool DebugMode { get; }
 
         /// <summary>
-        /// 0 (skip) - 3
+        /// -ve = disabled, 0 = skip, 1-3 = items
         /// </summary>
         int BoostItemSelectionMode { get; }
 

--- a/FateGrandAutomata/Preferences/FgoPreferences.cs
+++ b/FateGrandAutomata/Preferences/FgoPreferences.cs
@@ -96,7 +96,7 @@ namespace FateGrandAutomata
 
         public bool StopAfterBond10 => GetBool(R.pref_stop_bond10);
 
-        public int BoostItemSelectionMode => GetStringAsInt(R.pref_boost_item);
+        public int BoostItemSelectionMode => GetStringAsInt(R.pref_boost_item, -1);
 
         // TODO: Support debug mode
         public bool DebugMode => false;

--- a/FateGrandAutomata/Resources/values/arrays.xml
+++ b/FateGrandAutomata/Resources/values/arrays.xml
@@ -19,12 +19,14 @@
 
   <array name="boost_item_labels">
     <item>Disabled</item>
+    <item>Skip</item>
     <item>Item 1</item>
     <item>Item 2</item>
     <item>Item 3</item>
   </array>
 
   <string-array name="boost_item_values">
+    <item>-1</item>
     <item>0</item>
     <item>1</item>
     <item>2</item>

--- a/FateGrandAutomata/Resources/values/preferences.xml
+++ b/FateGrandAutomata/Resources/values/preferences.xml
@@ -10,7 +10,7 @@
     <string name="pref_fast_skip_dead">fast_skip_dead</string>
     <string name="pref_story_skip">story_skip</string>
     <string name="pref_stop_bond10">stop_bond10</string>
-    <string name="pref_boost_item">boost_item</string>
+    <string name="pref_boost_item">selected_boost_item</string>
     <string name="pref_withdraw_enabled">withdraw_enabled</string>
 
     <string name="pref_extract_def_support_imgs">extract_def_support_imgs</string>

--- a/FateGrandAutomata/Resources/xml/app_preferences.xml
+++ b/FateGrandAutomata/Resources/xml/app_preferences.xml
@@ -50,7 +50,7 @@
     app:defaultValue="false"/>
 
   <ListPreference
-    app:defaultValue="0"
+    app:defaultValue="-1"
     app:entries="@array/boost_item_labels"
     app:entryValues="@array/boost_item_values"
     app:key="@string/pref_boost_item"


### PR DESCRIPTION
Current Boost Item disabled still tries to click on Boost Items. This causes #72 to happen sometimes.
I'm adding a new item `Skip` which would behave like the current `Disabled` setting, i.e. click on the don't use boost item button. `Disabled` would now mean that boost item code is not run.

fixes #72