### PR TITLE
Close Extra info window after Targeted skill

### DIFF
--- a/FateGrandAutomata.Core/Modules/AutoSkill.cs
+++ b/FateGrandAutomata.Core/Modules/AutoSkill.cs
@@ -50,6 +50,11 @@ namespace FateGrandAutomata
         {
             Location.Click();
 
+            AutomataApi.Wait(0.5);
+
+            // Exit any extra menu
+            Game.BattleExtrainfoWindowCloseClick.Click();
+
             WaitForAnimationToFinish();
         }
 

--- a/FateGrandAutomata.Core/Modules/Game.cs
+++ b/FateGrandAutomata.Core/Modules/Game.cs
@@ -109,9 +109,9 @@ namespace FateGrandAutomata
         public static Location BattleSkill9Click { get; } = new Location(1800, 1160);
         public static Location BattleSkillOkClick { get; } = new Location(1680, 850);
 
-        public static Location BattleServant1Click { get; } = new Location(700, 880);
-        public static Location BattleServant2Click { get; } = new Location(1280, 880);
-        public static Location BattleServant3Click { get; } = new Location(1940, 880);
+        public static Location BattleServant1Click { get; } = new Location(700, 690);
+        public static Location BattleServant2Click { get; } = new Location(1280, 690);
+        public static Location BattleServant3Click { get; } = new Location(1940, 690);
 
         public static Location BattleMasterSkillOpenClick { get; } = new Location(2380, 640);
         public static Location BattleMasterSkill1Click { get; } = new Location(1820, 620);

--- a/FateGrandAutomata.Core/Modules/Game.cs
+++ b/FateGrandAutomata.Core/Modules/Game.cs
@@ -109,9 +109,9 @@ namespace FateGrandAutomata
         public static Location BattleSkill9Click { get; } = new Location(1800, 1160);
         public static Location BattleSkillOkClick { get; } = new Location(1680, 850);
 
-        public static Location BattleServant1Click { get; } = new Location(700, 690);
-        public static Location BattleServant2Click { get; } = new Location(1280, 690);
-        public static Location BattleServant3Click { get; } = new Location(1940, 690);
+        public static Location BattleServant1Click { get; } = new Location(700, 880);
+        public static Location BattleServant2Click { get; } = new Location(1280, 880);
+        public static Location BattleServant3Click { get; } = new Location(1940, 880);
 
         public static Location BattleMasterSkillOpenClick { get; } = new Location(2380, 640);
         public static Location BattleMasterSkill1Click { get; } = new Location(1820, 620);


### PR DESCRIPTION
This prevents servant info dialog from opening if the skill wasn't targetable.

fixes #78 

Not tested on JP yet.