### PR TITLE
Overlays shouldn't be visible on Lock screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.VIBRATE"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
     <application
         android:name=".util.AutomataApplication"

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/accessibility/ScriptRunnerDialog.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/accessibility/ScriptRunnerDialog.kt
@@ -28,7 +28,7 @@ class ScriptRunnerDialog(val UI: ScriptRunnerUserInterface) {
         inflater.inflate(R.layout.script_runner_dialog, frame)
 
         layoutParams = WindowManager.LayoutParams().apply {
-            type = WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY
+            type = UI.overlayType
             format = PixelFormat.TRANSLUCENT
             width = WindowManager.LayoutParams.MATCH_PARENT
             height = WindowManager.LayoutParams.MATCH_PARENT

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/accessibility/ScriptRunnerUserInterface.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/accessibility/ScriptRunnerUserInterface.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
 import android.graphics.PixelFormat
+import android.os.Build
 import android.util.DisplayMetrics
 import android.view.*
 import android.widget.FrameLayout
@@ -23,12 +24,19 @@ import kotlin.time.milliseconds
 class ScriptRunnerUserInterface(val Service: ScriptRunnerService) {
     private val layout = FrameLayout(Service)
 
+    val overlayType: Int get() {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+        }
+        else WindowManager.LayoutParams.TYPE_PHONE
+    }
+
     val windowManager = Service.getSystemService(Context.WINDOW_SERVICE) as WindowManager
 
     private val layoutParams = WindowManager.LayoutParams().apply {
-        type = WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY
+        type = overlayType
         format = PixelFormat.TRANSLUCENT
-        flags = WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+        flags = WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
         width = WindowManager.LayoutParams.WRAP_CONTENT
         height = WindowManager.LayoutParams.WRAP_CONTENT
         @SuppressLint("RtlHardcoded")
@@ -39,7 +47,7 @@ class ScriptRunnerUserInterface(val Service: ScriptRunnerService) {
     }
 
     private var highlightLayoutParams = WindowManager.LayoutParams().apply {
-        type = WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY
+        type = overlayType
         format = PixelFormat.TRANSLUCENT
         flags =
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/ui/MainActivity.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/ui/MainActivity.kt
@@ -109,8 +109,22 @@ class MainActivity : AppCompatActivity(), PreferenceFragmentCompat.OnPreferenceS
         return false
     }
 
+    private fun checkCanUseOverlays(): Boolean {
+        if (!Settings.canDrawOverlays(this)) {
+            val i = Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+                Uri.parse("package:$packageName"))
+            startActivity(i)
+            return false
+        }
+
+        return true
+    }
+
     private fun serviceToggleBtnOnClick() {
         if (!checkAccessibilityService())
+            return
+
+        if (!checkCanUseOverlays())
             return
 
         val instance = ScriptRunnerService.Instance


### PR DESCRIPTION
So, we can use `SYSTEM_ALERT_WINDOW` permission to show overlays (Play button, Highlights, Dialogs) instead of `TYPE_ACCESSIBILITY_OVERLAY` and they're not visible on the lock screen. The user will be taken to the screen to enable this permission on first run.

The behaviour is different for Android 7 and Android 8+. On Android 7, we use `TYPE_PHONE` and on Android 8+, we use `TYPE_APPLICATION_OVERLAY`.

### Test
- [x] Android 7
- [x] Android 9
- [x] Android 10
- [x] Nox Android 7 (has the same **play button can't move freely** problem)