### PR TITLE
GitHub Pages Website

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Auto-battle app for Fate/Grand Order Android.  
 
+Download from our [Website](https://MathewSachin.github.io/Fate-Grand-Automata).
+
 This is pretty much a ~~C#~~ **Kotlin** port of [Fate-Grand-Order_Lua][FGOLua] with UI for configuring Settings and inbuilt Sikuli like API.
 
 So, there's no time limit on the use of the app unlike FGO-Lua.

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,5 @@
+_drafts/
+_site/
+*.swp
+Gemfile.lock
+debug.log

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,14 @@
+lsi: false
+baseurl: /Fate-Grand-Automata
+
+name: Fate/Grand Automata
+description: Auto-battle app for Fate/Grand Order Android
+author: Mathew Sachin
+url: "https://MathewSachin.github.io/Fate-Grand-Automata"
+
+github: "https://github.com/MathewSachin/Fate-Grand-Automata"
+
+exclude: ["Gemfile", "Gemfile.lock"]
+
+plugins:
+  - jekyll-seo-tag  # Search Engine Optimization

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -1,0 +1,26 @@
+<head>
+  <meta charset="UTF-8"/>
+  <title>{% if page.title %}{{ page.title }}{% else %}{{ site.name }}{% endif %}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <meta content="IE=10.000" http-equiv="X-UA-Compatible"/>
+  
+  <link rel="icon" href="/images/favicon.png">
+  
+  <!-- Material Design Icons -->
+  <link rel="stylesheet" href="https://cdn.materialdesignicons.com/5.3.45/css/materialdesignicons.min.css">
+  <!-- Bootstrap core CSS -->
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet">
+  <!-- Material Design Bootstrap -->
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.8.10/css/mdb.min.css" rel="stylesheet">
+  
+  <!-- JQuery -->
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+  <!-- Bootstrap tooltips -->
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.4/umd/popper.min.js"></script>
+  <!-- Bootstrap core JavaScript -->
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/js/bootstrap.min.js"></script>
+  <!-- MDB core JavaScript -->
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.8.10/js/mdb.min.js"></script>
+
+  {% seo %}
+</head>

--- a/docs/_includes/navbar.html
+++ b/docs/_includes/navbar.html
@@ -1,0 +1,56 @@
+<style>
+  .icon-bar {
+    width: 25px; 
+    height: 3px;
+    background-color: #B6B6B6;
+    display: block;
+    transition: all 0.2s;
+    margin-top: 5px;
+  }
+  
+  .navbar-toggler .bar-t {
+    margin-top: 0;
+    transform: rotate(45deg);
+    transform-origin: left center;
+  }
+  
+  .navbar-toggler .bar-m {
+    opacity: 0;
+  }
+  
+  .navbar-toggler .bar-b {
+    transform: rotate(-45deg);
+    transform-origin: left center;
+  }
+  
+  .navbar-toggler.collapsed .bar-t {
+    transform: rotate(0);
+  }
+  
+  .navbar-toggler.collapsed .bar-m {
+    opacity: 1;
+  }
+  
+  .navbar-toggler.collapsed .bar-b {
+    transform: rotate(0);
+  }
+</style>
+
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container">
+    <a class="navbar-brand" href="{{ '/' | relative_url }}">{{site.name}}</a>
+    <!-- <button class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#navbarContent">
+      <span class="icon-bar bar-t"></span>
+      <span class="icon-bar bar-m"></span>
+      <span class="icon-bar bar-b"></span>
+    </button>
+    
+    <div class="collapse navbar-collapse" id="navbarContent">
+      <ul class="navbar-nav mr-auto">
+        <li class="nav-item">
+          <a class="nav-link" href=""></a>
+        </li>
+      </ul>
+    </div> -->
+  </div>
+</nav>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en-us">
+  {% include head.html %}
+  <body>
+    {% include navbar.html %}
+
+    {{ content }}  
+  </body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,40 @@
+---
+layout: default
+---
+
+<div class="jumbotron jumbotron-fluid peach-gradient text-white">
+  <div class="container text-center">
+    <h2>{{site.name}}</h2>
+
+    <small>{{site.description}}</small><br>
+
+    <i id="version-txt"></i><br>
+
+    <a class="btn peach" href="{{site.github}}"><i class="mdi mdi-github mr-1"></i> Source Code</a>
+    <a id="download-btn" target="_blank" class="btn aqua-gradient" href="{{site.github}}/releases"><i class="mdi mdi-download mr-1"></i> Download</a>
+  </div>
+</div>
+
+<script src="{{ '/scripts/download.js' | relative_url }}"></script>
+
+<div class="container text-center">
+  <div class="row">
+    <div class="col-md">
+      <i class="mdi mdi-auto-fix display-1 text-info"></i>
+      <br>
+      <div class="text-muted">Auto-skill maker makes it easy to automate your farming</div>
+    </div>
+    <div class="col-md">
+      <i class="mdi mdi-handshake display-1 text-success"></i>
+      <br>
+      <div class="text-muted">Support servant and CEs can be selected automatically</div>
+    </div>
+    <div class="col-md">
+      <i class="mdi mdi-food-apple-outline display-1 text-warning"></i>
+      <br>
+      <div class="text-muted">Can be set to automatically eat through your apples</div>
+    </div>
+  </div>
+</div>
+
+<br>

--- a/docs/scripts/download.js
+++ b/docs/scripts/download.js
@@ -1,0 +1,14 @@
+$(function() {
+  var link = "https://api.github.com/repos/MathewSachin/Fate-Grand-Automata/releases"
+  $.get(link, function(data) {
+    var releases = data
+    // We include pre-releases here
+    var latest = releases[0]
+
+    var asset = latest.assets[0]
+    var downloadLink = asset.browser_download_url
+
+    $("#download-btn").attr('href', downloadLink)
+    $('#version-txt').text(latest.tag_name)
+  })
+})


### PR DESCRIPTION
We really need a website with a button to download the app. Some users are not familiar with GitHub and are having trouble downloading the app. So, I quickly put up a basic website.

docsify is good and all, but it's more suited for programmer tools, we're more of an end-user app.

<img width="954" alt="Screenshot (116)" src="https://user-images.githubusercontent.com/10654537/82920034-6a8fb300-9f94-11ea-8cd7-a62347ce6647.png">
