### PR TITLE
Fix usage of DisplayMetrics

### DIFF
--- a/app/src/main/java/com/mathewsachin/fategrandautomata/accessibility/ScriptRunnerService.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/accessibility/ScriptRunnerService.kt
@@ -135,7 +135,7 @@ class ScriptRunnerService : AccessibilityService() {
             if (MediaProjectionToken != null) {
                 mediaProjection =
                     mediaProjectionManager.getMediaProjection(RESULT_OK, MediaProjectionToken)
-                MediaProjectionScreenshotService(mediaProjection!!, userInterface.metrics)
+                MediaProjectionScreenshotService(mediaProjection!!, userInterface.mediaProjectionMetrics)
             } else RootScreenshotService(
                 getSuperUser()
             )
@@ -247,7 +247,7 @@ class ScriptRunnerService : AccessibilityService() {
         entryPoint = EntryPoint
 
         if (Preferences.RecordScreen && mediaProjection != null) {
-            recording = MediaProjectionRecording(mediaProjection!!, userInterface.metrics)
+            recording = MediaProjectionRecording(mediaProjection!!, userInterface.mediaProjectionMetrics)
         }
 
         EntryPoint.scriptExitListener = ::onScriptExit


### PR DESCRIPTION
DisplayMetrics are re-read on starting the script or dragging play button (fixes #121).

Also fixes the problem of play button not moving freely on Nox.