### PR TITLE
Stop script if screen turns OFF

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android-extensions'
 android {
     compileSdkVersion 29
     buildToolsVersion "29.0.3"
-    ndkVersion "21.2.6472646"
+    ndkVersion "21.3.6528147"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/accessibility/ScriptRunnerService.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/accessibility/ScriptRunnerService.kt
@@ -44,6 +44,7 @@ import com.mathewsachin.fategrandautomata.ui.MainActivity
 import com.mathewsachin.fategrandautomata.ui.support_img_namer.SupportImageIdKey
 import com.mathewsachin.fategrandautomata.ui.support_img_namer.SupportImageNamerActivity
 import com.mathewsachin.fategrandautomata.util.AndroidImpl
+import com.mathewsachin.fategrandautomata.util.ScreenOffReceiver
 import com.mathewsachin.fategrandautomata.util.getAutoSkillEntries
 import com.mathewsachin.libautomata.messageAndStackTrace
 import kotlin.time.seconds
@@ -76,6 +77,7 @@ class ScriptRunnerService : AccessibilityService() {
     private var sshotService: IScreenshotService? = null
     private var gestureService: IGestureService? = null
     private var superUser: SuperUser? = null
+    private val screenOffReceiver = ScreenOffReceiver()
 
     // stopping is handled by Screenshot service
     private var mediaProjection: MediaProjection? = null
@@ -93,6 +95,8 @@ class ScriptRunnerService : AccessibilityService() {
     override fun onUnbind(intent: Intent?): Boolean {
         stop()
 
+        unregisterReceiver(screenOffReceiver)
+        screenOffReceiver.screenOffListener = { }
         Instance = null
 
         return super.onUnbind(intent)
@@ -360,6 +364,9 @@ class ScriptRunnerService : AccessibilityService() {
             getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
 
         userInterface = ScriptRunnerUserInterface(this)
+
+        screenOffReceiver.register(this)
+        screenOffReceiver.screenOffListener = { stopScript() }
 
         super.onServiceConnected()
     }

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/util/ScreenOffReceiver.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/util/ScreenOffReceiver.kt
@@ -1,0 +1,23 @@
+package com.mathewsachin.fategrandautomata.util
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+
+class ScreenOffReceiver : BroadcastReceiver() {
+
+    fun register(Context: Context) {
+        val filter = IntentFilter(Intent.ACTION_SCREEN_OFF)
+
+        Context.registerReceiver(this, filter)
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.action) {
+            Intent.ACTION_SCREEN_OFF -> screenOffListener()
+        }
+    }
+
+    var screenOffListener: () -> Unit = { }
+}


### PR DESCRIPTION
Useful with for e.g. Lottery script if the play button doesn't respond.
The lottery script clicks so much that sometimes you won't be able to stop by pressing on the play button, so just lock the phone to stop the script.
Also, would save battery in cases where screen turns OFF due to some reason and the app is stuck in a loop.