### PR TITLE
Fix: Friend lock can cause Support Servant matching to fail

### DIFF
--- a/app/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Support.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Support.kt
@@ -247,8 +247,9 @@ class Support {
     private fun findServants(): Sequence<Region> = sequence {
         for (preferredServant in preferredServantArray) {
             // Cached pattern. Don't dispose here.
-            val pattern = loadSupportImagePattern(preferredServant)
-                .cropFriendLock()
+            val pattern = cropFriendLock(
+                loadSupportImagePattern(preferredServant)
+            )
 
             for (servant in Game.SupportListRegion.findAll(pattern)) {
                 yield(servant.Region)
@@ -263,10 +264,13 @@ class Support {
      * which would need everyone to regenerate their images,
      * crop out the part which can potentially have the lock.
      */
-    private fun IPattern.cropFriendLock(): IPattern {
+    private fun cropFriendLock(servant: IPattern): IPattern {
         val lockCropLeft = 15
-        val lockCropRegion = Region(lockCropLeft, 0, width - lockCropLeft, height)
-        return crop(lockCropRegion)
+        val lockCropRegion = Region(
+            lockCropLeft, 0,
+            servant.width - lockCropLeft, servant.height
+        )
+        return servant.crop(lockCropRegion)
     }
 
     private fun findCraftEssence(SearchRegion: Region): Region? {

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Support.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Support.kt
@@ -260,6 +260,7 @@ class Support {
     /**
      * If you lock your friends, a lock icon shows on the left of servant image,
      * which can cause matching to fail.
+     *
      * Instead of modifying in-built images and Support Image Maker,
      * which would need everyone to regenerate their images,
      * crop out the part which can potentially have the lock.

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Support.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Support.kt
@@ -1,11 +1,11 @@
 package com.mathewsachin.fategrandautomata.scripts.modules
 
-import com.mathewsachin.libautomata.*
 import com.mathewsachin.fategrandautomata.scripts.ImageLocator
 import com.mathewsachin.fategrandautomata.scripts.enums.SupportSearchResultEnum
 import com.mathewsachin.fategrandautomata.scripts.enums.SupportSelectionModeEnum
 import com.mathewsachin.fategrandautomata.scripts.loadSupportImagePattern
 import com.mathewsachin.fategrandautomata.scripts.prefs.Preferences
+import com.mathewsachin.libautomata.*
 import kotlin.time.seconds
 
 private data class PreferredCEEntry(val Name: String, val PreferMlb: Boolean)
@@ -248,11 +248,25 @@ class Support {
         for (preferredServant in preferredServantArray) {
             // Cached pattern. Don't dispose here.
             val pattern = loadSupportImagePattern(preferredServant)
+                .cropFriendLock()
 
             for (servant in Game.SupportListRegion.findAll(pattern)) {
                 yield(servant.Region)
             }
         }
+    }
+
+    /**
+     * If you lock your friends, a lock icon shows on the left of servant image,
+     * which can cause matching to fail.
+     * Instead of modifying in-built images and Support Image Maker,
+     * which would need everyone to regenerate their images,
+     * crop out the part which can potentially have the lock.
+     */
+    private fun IPattern.cropFriendLock(): IPattern {
+        val lockCropLeft = 15
+        val lockCropRegion = Region(lockCropLeft, 0, width - lockCropLeft, height)
+        return crop(lockCropRegion)
     }
 
     private fun findCraftEssence(SearchRegion: Region): Region? {


### PR DESCRIPTION
If you lock your friends, a lock icon shows on the left of servant image, which can cause matching to fail.

Instead of modifying in-built images and Support Image Maker, which would need everyone to regenerate their images,
we crop out the part which can potentially have the lock.

fixes #157 