### PR TITLE
Auto-detect GameServer

### DIFF
--- a/app/src/main/java/com/mathewsachin/fategrandautomata/accessibility/ScriptRunnerService.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/accessibility/ScriptRunnerService.kt
@@ -19,10 +19,7 @@ import com.mathewsachin.fategrandautomata.root.RootScreenshotService
 import com.mathewsachin.fategrandautomata.root.SuperUser
 import com.mathewsachin.fategrandautomata.scripts.clearImageCache
 import com.mathewsachin.fategrandautomata.scripts.prefs.Preferences
-import com.mathewsachin.fategrandautomata.util.AndroidImpl
-import com.mathewsachin.fategrandautomata.util.ScreenOffReceiver
-import com.mathewsachin.fategrandautomata.util.ScriptManager
-import com.mathewsachin.fategrandautomata.util.setThrottledClickListener
+import com.mathewsachin.fategrandautomata.util.*
 import com.mathewsachin.libautomata.*
 
 class ScriptRunnerService : AccessibilityService() {
@@ -146,6 +143,11 @@ class ScriptRunnerService : AccessibilityService() {
                 scriptManager.stopScript()
             }
             else sshotService?.let {
+                // Auto-detect Server
+                fgoPackageNames
+                    .firstOrNull { m -> m.pkgName == foregroundAppName }
+                    ?.let { m -> Preferences.GameServer = m.server }
+
                 scriptManager.startScript(this, it)
             }
         }
@@ -173,7 +175,15 @@ class ScriptRunnerService : AccessibilityService() {
 
     override fun onInterrupt() {}
 
-    override fun onAccessibilityEvent(event: AccessibilityEvent?) {}
+    private var foregroundAppName = ""
+
+    override fun onAccessibilityEvent(event: AccessibilityEvent?) {
+        when (event?.eventType) {
+            AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> {
+                foregroundAppName = event.packageName.toString()
+            }
+        }
+    }
 
     fun showMessageBox(Title: String, Message: String, Error: Exception? = null) {
         ScriptRunnerDialog(userInterface).apply {

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/scripts/prefs/Preferences.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/scripts/prefs/Preferences.kt
@@ -1,9 +1,11 @@
 package com.mathewsachin.fategrandautomata.scripts.prefs
 
+import androidx.core.content.edit
 import com.mathewsachin.fategrandautomata.R
 import com.mathewsachin.fategrandautomata.scripts.enums.BattleNoblePhantasmEnum
 import com.mathewsachin.fategrandautomata.scripts.enums.GameServerEnum
 import com.mathewsachin.fategrandautomata.scripts.enums.ScriptModeEnum
+import com.mathewsachin.fategrandautomata.util.AutomataApplication
 
 class Preferences {
     companion object {
@@ -13,7 +15,12 @@ class Preferences {
 
         val ScriptMode get() = getEnumPref(R.string.pref_script_mode, ScriptModeEnum.Battle)
 
-        val GameServer get() = getEnumPref(R.string.pref_gameserver, GameServerEnum.En)
+        var GameServer get() = getEnumPref(R.string.pref_gameserver, GameServerEnum.En)
+            set(value) {
+                defaultPrefs.edit(commit = true) {
+                    putString(AutomataApplication.Instance.getString(R.string.pref_gameserver), value.toString())
+                }
+            }
 
         val SkillConfirmation get() = getBoolPref(R.string.pref_skill_conf)
 

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/MainSettingsFragment.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/MainSettingsFragment.kt
@@ -1,7 +1,6 @@
 package com.mathewsachin.fategrandautomata.ui.prefs
 
 import android.os.Bundle
-import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.mathewsachin.fategrandautomata.R
@@ -37,12 +36,6 @@ class MainSettingsFragment : PreferenceFragmentCompat() {
                 true -> "${prefs.resource} x${prefs.repetitions}"
                 false -> "OFF"
             }
-        }
-
-        // Since GameServer can be updated from other parts of code,
-        // we need to trigger a forced UI update here
-        findPreference<ListPreference>(getString(R.string.pref_gameserver))?.let {
-            it.value = Preferences.GameServer.toString()
         }
     }
 }

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/MainSettingsFragment.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/MainSettingsFragment.kt
@@ -1,6 +1,7 @@
 package com.mathewsachin.fategrandautomata.ui.prefs
 
 import android.os.Bundle
+import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.mathewsachin.fategrandautomata.R
@@ -36,6 +37,12 @@ class MainSettingsFragment : PreferenceFragmentCompat() {
                 true -> "${prefs.resource} x${prefs.repetitions}"
                 false -> "OFF"
             }
+        }
+
+        // Since GameServer can be updated from other parts of code,
+        // we need to trigger a forced UI update here
+        findPreference<ListPreference>(getString(R.string.pref_gameserver))?.let {
+            it.value = Preferences.GameServer.toString()
         }
     }
 }

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/MoreSettingsFragment.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/MoreSettingsFragment.kt
@@ -2,9 +2,11 @@ package com.mathewsachin.fategrandautomata.ui.prefs
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.mathewsachin.fategrandautomata.R
+import com.mathewsachin.fategrandautomata.scripts.prefs.Preferences
 import com.mathewsachin.fategrandautomata.scripts.prefs.defaultCardPriority
 import com.mathewsachin.fategrandautomata.scripts.prefs.getStringPref
 import com.mathewsachin.fategrandautomata.ui.card_priority.CardPriorityActivity
@@ -23,6 +25,12 @@ class MoreSettingsFragment : PreferenceFragmentCompat() {
 
     override fun onResume() {
         super.onResume()
+
+        // Since GameServer can be updated from other parts of code,
+        // we need to trigger a forced UI update here
+        findPreference<ListPreference>(getString(R.string.pref_gameserver))?.let {
+            it.value = Preferences.GameServer.toString()
+        }
 
         findPreference<Preference>(getString(R.string.pref_card_priority))?.let {
             it.summary = getStringPref(R.string.pref_card_priority, defaultCardPriority)

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/util/FgoPackageNames.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/util/FgoPackageNames.kt
@@ -1,0 +1,10 @@
+package com.mathewsachin.fategrandautomata.util
+
+import com.mathewsachin.fategrandautomata.scripts.enums.GameServerEnum
+
+data class FgoPackageNames(val server: GameServerEnum, val pkgName: String)
+
+val fgoPackageNames = listOf(
+    FgoPackageNames(GameServerEnum.En, "com.aniplex.fategrandorder.en"),
+    FgoPackageNames(GameServerEnum.Jp, "com.aniplex.fategrandorder")
+)

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/util/FgoPackageNames.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/util/FgoPackageNames.kt
@@ -6,5 +6,7 @@ data class FgoPackageNames(val server: GameServerEnum, val pkgName: String)
 
 val fgoPackageNames = listOf(
     FgoPackageNames(GameServerEnum.En, "com.aniplex.fategrandorder.en"),
-    FgoPackageNames(GameServerEnum.Jp, "com.aniplex.fategrandorder")
+    FgoPackageNames(GameServerEnum.Jp, "com.aniplex.fategrandorder"),
+    FgoPackageNames(GameServerEnum.Cn, "com.bilibili.fatego.sharejoy"),
+    FgoPackageNames(GameServerEnum.Tw, "com.komoe.fgomycard")
 )

--- a/app/src/main/res/xml/app_preferences.xml
+++ b/app/src/main/res/xml/app_preferences.xml
@@ -1,6 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <ListPreference
+        app:defaultValue="En"
+        app:entries="@array/game_server_labels"
+        app:entryValues="@array/game_server_values"
+        app:icon="@drawable/ic_earth"
+        app:key="@string/pref_gameserver"
+        app:title="Game Server"
+        app:useSimpleSummaryProvider="true" />
+
     <Preference
         app:icon="@drawable/ic_sort"
         app:key="@string/pref_card_priority"

--- a/app/src/main/res/xml/main_preferences.xml
+++ b/app/src/main/res/xml/main_preferences.xml
@@ -10,15 +10,6 @@
         app:title="Script Mode"
         app:useSimpleSummaryProvider="true" />
 
-    <ListPreference
-        app:defaultValue="En"
-        app:entries="@array/game_server_labels"
-        app:entryValues="@array/game_server_values"
-        app:icon="@drawable/ic_earth"
-        app:key="@string/pref_gameserver"
-        app:title="Game Server"
-        app:useSimpleSummaryProvider="true" />
-
     <Preference
         app:icon="@drawable/ic_apple"
         app:key="@string/pref_nav_refill"

--- a/app/src/main/res/xml/script_runner_service.xml
+++ b/app/src/main/res/xml/script_runner_service.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityEventTypes="typeWindowStateChanged"
     android:accessibilityFlags="flagDefault"
     android:canPerformGestures="true"
     android:canRetrieveWindowContent="true"


### PR DESCRIPTION
We can automatically set the `GameServer` if we can detect the package name of FGO running in the foreground.

Turns out `AccessibilityServices` can check the app in the foreground pretty easily.
So, we just need to match it with the package name of different versions of FGO.

I only did for NA and JP since I only know their package names.

NA: `com.aniplex.fategrandorder.en`
JP: `com.aniplex.fategrandorder`

~~I'm not able to find package names for CN and TW on the internet, can you help?~~
~~CN: @caoli5288~~
~~TW: @the3dsandwich~~
~~You should be able to see the package name of FGO in Android's App info menu depending on your phone model.~~
Nevermind, someone gave me the package names for CN and TW on Gamepress:

CN: `com.bilibili.fatego.sharejoy`
TW: `com.komoe.fgomycard`

Also, moved the `GameServer` option to `More options` since it is not important to manually set it anymore.