### PR TITLE
Configurable Skill Delay

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode Integer.valueOf(System.env.FGA_VERSION_CODE ?: 1)
-        versionName(System.env.FGA_VERSION_NAME ?: "v0.1.0")
+        versionName(System.env.FGA_VERSION_NAME ?: "0.1.0")
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/res/xml/fine_tune_preferences.xml
+++ b/app/src/main/res/xml/fine_tune_preferences.xml
@@ -121,6 +121,16 @@
         app:key="wait_category"
         app:title="Wait">
         <SeekBarPreference
+            android:max="2000"
+            app:defaultValue="500"
+            app:key="@string/pref_skill_delay"
+            app:icon="@drawable/ic_wand"
+            app:min="100"
+            app:seekBarIncrement="10"
+            app:showSeekBarValue="true"
+            app:title="Skill Delay (ms)" />
+
+        <SeekBarPreference
             android:max="200"
             app:defaultValue="100"
             app:key="@string/pref_wait_multiplier"

--- a/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/Preferences.kt
+++ b/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/Preferences.kt
@@ -85,6 +85,8 @@ class PreferencesImpl @Inject constructor(
 
     override val recordScreen by prefs.bool(R.string.pref_record_screen)
 
+    override val skillDelay by prefs.int(R.string.pref_skill_delay, 500).map { it.milliseconds }
+
     override fun forAutoSkillConfig(id: String): IAutoSkillPreferences =
         AutoSkillPreferences(
             id,

--- a/prefs/src/main/res/values/preferences.xml
+++ b/prefs/src/main/res/values/preferences.xml
@@ -56,6 +56,8 @@
     <string name="pref_wait_multiplier">wait_multiplier</string>
     <string name="pref_support_swipe_multiplier">support_swipe_multiplier</string>
 
+    <string name="pref_skill_delay">skill_delay</string>
+
     <string name="pref_nav_refill">nav_refill</string>
     <string name="pref_nav_auto_skill">nav_auto_skill</string>
     <string name="pref_nav_more">nav_more</string>

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/AutoSkill.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/AutoSkill.kt
@@ -77,7 +77,7 @@ class AutoSkill(fgAutomataApi: IFGAutomataApi) : IFGAutomataApi by fgAutomataApi
         val img = images.battle
 
         // slow devices need this. do not remove.
-        game.battleScreenRegion.waitVanish(img, 2.seconds)
+        game.battleScreenRegion.waitVanish(img, prefs.skillDelay)
 
         game.battleScreenRegion.exists(img, Timeout)
     }

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/prefs/IPreferences.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/prefs/IPreferences.kt
@@ -4,6 +4,7 @@ import com.mathewsachin.fategrandautomata.scripts.enums.BattleNoblePhantasmEnum
 import com.mathewsachin.fategrandautomata.scripts.enums.GameServerEnum
 import com.mathewsachin.fategrandautomata.scripts.enums.ScriptModeEnum
 import com.mathewsachin.libautomata.IPlatformPrefs
+import kotlin.time.Duration
 
 interface IPreferences {
     val scriptMode: ScriptModeEnum
@@ -23,6 +24,7 @@ interface IPreferences {
     val useRootForScreenshots: Boolean
     val gudaFinal: Boolean
     val recordScreen: Boolean
+    val skillDelay: Duration
 
     val support: ISupportPreferencesCommon
     val platformPrefs: IPlatformPrefs


### PR DESCRIPTION
Requested by @tchofy
For info, see https://github.com/MathewSachin/Fate-Grand-Automata/issues/187#issuecomment-660608387

Made the 2s delay configurable and set its default to 500ms.
I think It should be a good default for everyone.