### PR TITLE
Fix: Story Skip

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.github.iamareebjamal:opencv-android:4.3.0'
+    implementation 'com.github.iamareebjamal:opencv-android:4.4.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/imaging/DroidCvPattern.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/imaging/DroidCvPattern.kt
@@ -92,16 +92,16 @@ class DroidCvPattern(
             val result = DisposableMat()
 
             if (Template.width <= width && Template.height <= height) {
-                alpha.let { mask ->
-                    if (mask != null) {
-                        Imgproc.matchTemplate(
-                            Mat,
-                            Template.Mat,
-                            result.Mat,
-                            Imgproc.TM_CCOEFF_NORMED,
-                            mask
-                        )
-                    } else Imgproc.matchTemplate(
+                if (alpha != null) {
+                    Imgproc.matchTemplate(
+                        Mat,
+                        Template.Mat,
+                        result.Mat,
+                        Imgproc.TM_CCOEFF_NORMED,
+                        alpha
+                    )
+                } else {
+                    Imgproc.matchTemplate(
                         Mat,
                         Template.Mat,
                         result.Mat,

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/imaging/DroidCvPattern.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/imaging/DroidCvPattern.kt
@@ -12,17 +12,34 @@ import java.io.InputStream
 import kotlin.math.roundToInt
 import org.opencv.core.Size as CvSize
 
-class DroidCvPattern(private var Mat: Mat? = Mat(), private val OwnsMat: Boolean = true) :
-    IPattern {
-    constructor() : this(Mat())
+class DroidCvPattern(
+    private var Mat: Mat? = Mat(),
+    private val OwnsMat: Boolean = true
+) : IPattern {
+    private data class MatWithAlpha(val mat: Mat, val alpha: Mat?)
+
+    var alpha: Mat? = null
 
     private companion object {
-        fun makeMat(Stream: InputStream): Mat {
+        fun makeMat(Stream: InputStream): MatWithAlpha {
             val byteArray = Stream.readBytes()
             DisposableMat(MatOfByte(*byteArray)).use {
-                return Imgcodecs.imdecode(it.Mat, Imgcodecs.IMREAD_GRAYSCALE)
+                val decoded = Imgcodecs.imdecode(it.Mat, Imgcodecs.IMREAD_UNCHANGED)
+
+                // If there are 4 channels (RGBA), last one is alpha
+                val alphaChannel = if (decoded.channels() == 4) {
+                    Mat().apply { Core.extractChannel(decoded, this, 3) }
+                } else null
+
+                Imgproc.cvtColor(decoded, decoded, Imgproc.COLOR_RGBA2GRAY)
+
+                return MatWithAlpha(decoded, alphaChannel)
             }
         }
+    }
+
+    private constructor(matWithAlpha: MatWithAlpha) : this(matWithAlpha.mat) {
+        alpha = matWithAlpha.alpha
     }
 
     constructor(Stream: InputStream, tag: String) : this(makeMat(Stream)) {
@@ -75,9 +92,23 @@ class DroidCvPattern(private var Mat: Mat? = Mat(), private val OwnsMat: Boolean
             val result = DisposableMat()
 
             if (Template.width <= width && Template.height <= height) {
-                Imgproc.matchTemplate(Mat, Template.Mat, result.Mat, Imgproc.TM_CCOEFF_NORMED)
-            }
-            else logd("Skipped matching $Template: Region out of bounds")
+                alpha.let { mask ->
+                    if (mask != null) {
+                        Imgproc.matchTemplate(
+                            Mat,
+                            Template.Mat,
+                            result.Mat,
+                            Imgproc.TM_CCOEFF_NORMED,
+                            mask
+                        )
+                    } else Imgproc.matchTemplate(
+                        Mat,
+                        Template.Mat,
+                        result.Mat,
+                        Imgproc.TM_CCOEFF_NORMED
+                    )
+                }
+            } else logd("Skipped matching $Template: Region out of bounds")
 
             return result
         }

--- a/app/src/main/res/xml/app_preferences.xml
+++ b/app/src/main/res/xml/app_preferences.xml
@@ -98,7 +98,7 @@
             app:defaultValue="false"
             app:icon="@drawable/ic_key"
             app:key="@string/pref_use_root_screenshot"
-            app:summary="Useful on Nox (Android 7). Toggle service after change this."
+            app:summary="Useful on Nox (Android 7). Toggle service after changing this."
             app:title="Use Root for Screenshots" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoBattle.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoBattle.kt
@@ -50,7 +50,8 @@ open class AutoBattle(
             { isInQuestRewardScreen() } to { questReward() },
             { isInSupport() } to { support() },
             { needsToWithdraw() } to { withdraw() },
-            { isGudaFinalRewardsScreen() } to { gudaFinalReward() }
+            { needsToStorySkip() } to { skipStory() }
+            //{ isGudaFinalRewardsScreen() } to { gudaFinalReward() }
         )
 
         // Loop through SCREENS until a Validator returns true
@@ -188,17 +189,7 @@ open class AutoBattle(
             }
         }
 
-        // Post-battle story is sometimes there.
-        if (prefs.storySkip) {
-            if (game.menuStorySkipRegion.exists(images.storySkip)) {
-                game.menuStorySkipClick.click()
-                0.5.seconds.wait()
-                game.menuStorySkipYesClick.click()
-            }
-        }
-
-        10.seconds.wait()
-
+        // TODO: Move to outer loop
         // Quest Completion reward. Exits the screen when it is presented.
         if (game.resultCeRewardRegion.exists(images.bond10Reward)) {
             game.resultCeRewardCloseClick.click()
@@ -293,10 +284,13 @@ open class AutoBattle(
     /**
      * Checks if the SKIP button exists on the screen.
      */
-    private fun needsToStorySkip(): Boolean {
-        // TODO: Story Skip doesn't work correctly
-        //if (game.MenuStorySkipRegion.exists(images.StorySkip))
-        return prefs.storySkip
+    private fun needsToStorySkip() =
+        prefs.storySkip && game.menuStorySkipRegion.exists(images.storySkip, Similarity = 0.7)
+
+    private fun skipStory() {
+        game.menuStorySkipClick.click()
+        0.5.seconds.wait()
+        game.menuStorySkipYesClick.click()
     }
 
     /**
@@ -366,16 +360,6 @@ open class AutoBattle(
 
             // in case you run out of items
             game.menuBoostItemSkipClick.click()
-        }
-
-        if (prefs.storySkip) {
-            10.seconds.wait()
-
-            if (needsToStorySkip()) {
-                game.menuStorySkipClick.click()
-                0.5.seconds.wait()
-                game.menuStorySkipYesClick.click()
-            }
         }
     }
 


### PR DESCRIPTION
fixes #148 

OpenCV release v4.4 which adds support for matching transparent images.
So, we can now reliably match Story Skip image which needs to be transparent.

I've added Story Skip check to the outer loop so it doesn't matter whenever it comes up it can get matched.

I was getting around 0.77 similarity when matching, and 0.44 when not matching, so I've set the similarity at 0.7.

After this PR is merged, I plan to take more things out of the `result` function. Specifically, I want to make the app respond faster to the free quest repeat dialog.