### PR TITLE
Fix: 10x summon (continue) misclick

### DIFF
--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoFriendGacha.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoFriendGacha.kt
@@ -15,7 +15,7 @@ class AutoFriendGacha @Inject constructor(
 ) : EntryPoint(exitManager, platformImpl), IFGAutomataApi by fgAutomataApi {
     private val first10SummonClick = Location(1400, 1120)
     private val okClick = Location(1600, 1120)
-    private val continueSummonClick = Location(1600, 1420)
+    private val continueSummonClick = Location(1600, 1325)
     private val skipRapidClick = Location(2520, 1400)
 
     private val continueSummonRegion = Region(1244, 1264, 580, 170)


### PR DESCRIPTION
The old location for `continueSummonClick` didn't even register on my phone, so I moved it slightly up:
![Screenshot_20200807-123004_Fate_GO](https://user-images.githubusercontent.com/4316326/89714552-d9ff2700-d975-11ea-8b00-ad1b504c8e6c.png)

[Before](https://www.youtube.com/watch?v=E5b1LFgE8_s) and [after](https://www.youtube.com/watch?v=lkoki9sQddg) video comparison. I'm not sure if JP's layout is different. D: