### PR TITLE
Better handling of Bond/Reward CEs

### DIFF
--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoBattle.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoBattle.kt
@@ -129,24 +129,18 @@ open class AutoBattle @Inject constructor(
      * too few clicks.
      */
     private fun isInResult(): Boolean {
-        if (images.result in Game.resultScreenRegion
-            || images.bond in Game.resultBondRegion
-            // We're assuming CN and TW use the same Master/Mystic Code Level up image
-            || images.masterLvlUp in Game.resultMasterLvlUpRegion
-        ) {
-            return true
+        val cases = sequenceOf(
+            images.result to Game.resultScreenRegion,
+            images.bond to Game.resultBondRegion,
+            images.masterLvlUp to Game.resultMasterLvlUpRegion,
+            images.masterExp to Game.resultMasterExpRegion,
+            images.matRewards to Game.resultMatRewardsRegion,
+            images.bond10Reward to Game.resultCeRewardRegion
+        )
+
+        return cases.any { (image, region) ->
+            image in region
         }
-
-        val gameServer = prefs.gameServer
-
-        // We don't have TW images for these
-        if (gameServer != GameServerEnum.Tw) {
-            return images.masterExp in Game.resultMasterExpRegion
-                    || images.matRewards in Game.resultMatRewardsRegion
-        }
-
-        // Not in any result screen
-        return false
     }
 
     /**
@@ -238,15 +232,13 @@ open class AutoBattle @Inject constructor(
     }
 
     private fun isCeReward() =
-        images.bond10Reward in Game.resultCeRewardRegion
+        images.bond10Reward in Game.resultCeRewardDetailsRegion
 
     private fun ceReward() {
         if (prefs.stopOnCEGet) {
             throw ScriptExitException("CE GET!")
         }
 
-        Game.resultCeRewardCloseClick.click()
-        1.seconds.wait()
         Game.resultCeRewardCloseClick.click()
     }
 

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoBattle.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoBattle.kt
@@ -134,13 +134,11 @@ open class AutoBattle @Inject constructor(
             images.bond to Game.resultBondRegion,
             images.masterLvlUp to Game.resultMasterLvlUpRegion,
             images.masterExp to Game.resultMasterExpRegion,
-            images.matRewards to Game.resultMatRewardsRegion,
-            images.bond10Reward to Game.resultCeRewardRegion
+            images.matRewards to Game.resultMatRewardsRegion
         )
 
-        return cases.any { (image, region) ->
-            image in region
-        }
+        return cases.any { (image, region) -> image in region }
+                || Game.resultCeRewardRegion.exists(images.bond10Reward, Similarity = ceRewardSimilarity)
     }
 
     /**
@@ -232,7 +230,9 @@ open class AutoBattle @Inject constructor(
     }
 
     private fun isCeReward() =
-        images.bond10Reward in Game.resultCeRewardDetailsRegion
+        Game.resultCeRewardDetailsRegion.exists(images.bond10Reward, Similarity = ceRewardSimilarity)
+
+    val ceRewardSimilarity = 0.75
 
     private fun ceReward() {
         if (prefs.stopOnCEGet) {

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Game.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Game.kt
@@ -100,6 +100,7 @@ class Game @Inject constructor(val prefs: IPreferences) {
 
         val resultCeDropRegion = Region(1860, 0, 240, 100)
         val resultCeRewardRegion = Region(1050, 1216, 33, 28)
+        val resultCeRewardDetailsRegion = Region(300, 1290, 60, 40)
         val resultCeRewardCloseClick = Location(80, 60)
         val resultFriendRequestRegion = Region(660, 120, 140, 160)
         val resultFriendRequestRejectClick = Location(600, 1200)

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Game.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Game.kt
@@ -100,7 +100,7 @@ class Game @Inject constructor(val prefs: IPreferences) {
 
         val resultCeDropRegion = Region(1860, 0, 240, 100)
         val resultCeRewardRegion = Region(1050, 1216, 33, 28)
-        val resultCeRewardDetailsRegion = Region(300, 1290, 60, 40)
+        val resultCeRewardDetailsRegion = Region(310, 1295, 45, 30)
         val resultCeRewardCloseClick = Location(80, 60)
         val resultFriendRequestRegion = Region(660, 120, 140, 160)
         val resultFriendRequestRejectClick = Location(600, 1200)


### PR DESCRIPTION
If the script somehow clicked on a Bond CE when clicking rapidly, it can get stuck there.
This fix adds another check for the CE details screen.