### PR TITLE
Play notification sound when script stops

### DIFF
--- a/app/src/main/java/com/mathewsachin/fategrandautomata/accessibility/ScriptRunnerNotification.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/accessibility/ScriptRunnerNotification.kt
@@ -1,9 +1,6 @@
 package com.mathewsachin.fategrandautomata.accessibility
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.app.PendingIntent
-import android.app.Service
+import android.app.*
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -107,7 +104,7 @@ class ScriptRunnerNotification @Inject constructor(val service: Service) {
             .setContentTitle(service.getString(R.string.app_name))
             .setContentText(msg)
             .setSmallIcon(R.mipmap.notification_icon)
-            .setPriority(NotificationManager.IMPORTANCE_DEFAULT)
+            .setDefaults(Notification.DEFAULT_SOUND)
             .setTimeoutAfter(10_000) // 10s
             .build()
 

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/util/AndroidImpl.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/util/AndroidImpl.kt
@@ -4,6 +4,7 @@ import android.app.Service
 import android.content.Context
 import android.os.*
 import android.widget.Toast
+import com.mathewsachin.fategrandautomata.accessibility.ScriptRunnerNotification
 import com.mathewsachin.fategrandautomata.accessibility.ScriptRunnerService
 import com.mathewsachin.fategrandautomata.imaging.DroidCvPattern
 import com.mathewsachin.fategrandautomata.scripts.prefs.IPreferences
@@ -21,6 +22,7 @@ import kotlin.time.milliseconds
 
 class AndroidImpl @Inject constructor(
     service: Service,
+    val notification: ScriptRunnerNotification,
     val preferences: IPreferences,
     val cutoutManager: CutoutManager,
     val highlightManager: HighlightManager
@@ -39,6 +41,8 @@ class AndroidImpl @Inject constructor(
                 .show()
         }
     }
+
+    override fun notify(message: String) = notification.message(message)
 
     override fun getResizableBlankPattern(): IPattern {
         return DroidCvPattern()

--- a/libautomata/src/main/java/com/mathewsachin/libautomata/EntryPoint.kt
+++ b/libautomata/src/main/java/com/mathewsachin/libautomata/EntryPoint.kt
@@ -28,12 +28,14 @@ abstract class EntryPoint(
             script()
         } catch (e: ScriptAbortException) {
             // Script stopped by user
+            platformImpl.notify("Script stopped by user or screen turned OFF")
         } catch (e: ScriptExitException) {
             scriptExitListener.invoke(e)
 
             // Show the message box only if there is some message
             if (!e.message.isBlank()) {
                 platformImpl.messageBox("Script Exited", e.message)
+                platformImpl.notify("Script Exited")
             }
         } catch (e: Exception) {
             println(e.messageAndStackTrace)
@@ -41,6 +43,7 @@ abstract class EntryPoint(
             scriptExitListener.invoke(e)
 
             platformImpl.messageBox("Unexpected Error", e.messageAndStackTrace, e)
+            platformImpl.notify("Unexpected Error")
         }
 
         try {

--- a/libautomata/src/main/java/com/mathewsachin/libautomata/IPlatformImpl.kt
+++ b/libautomata/src/main/java/com/mathewsachin/libautomata/IPlatformImpl.kt
@@ -12,6 +12,8 @@ interface IPlatformImpl {
      */
     fun toast(Message: String)
 
+    fun notify(message: String)
+
     /**
      * Creates a new [IPattern] without any image data.
      */

--- a/libautomata/src/main/java/com/mathewsachin/libautomata/extensions/AutomataApi.kt
+++ b/libautomata/src/main/java/com/mathewsachin/libautomata/extensions/AutomataApi.kt
@@ -26,5 +26,7 @@ class AutomataApi @Inject constructor(
             .copy() // It is important that the image gets cloned here.
 
     override fun toast(msg: String) = platformImpl.toast(msg)
+
+    override fun notify(msg: String) = platformImpl.notify(msg)
 }
 

--- a/libautomata/src/main/java/com/mathewsachin/libautomata/extensions/IAutomataExtensions.kt
+++ b/libautomata/src/main/java/com/mathewsachin/libautomata/extensions/IAutomataExtensions.kt
@@ -19,4 +19,6 @@ interface IAutomataExtensions : IDurationExtensions,
     val screenshotManager: ScreenshotManager
 
     fun toast(msg: String)
+
+    fun notify(msg: String)
 }


### PR DESCRIPTION
~~Haven't tested on Android 7 yet. Charging my old phone right now so that it at least boots.~~

Tested on Android 10 which should be same as for 8 and 9.

A notification is sent by the app when a script stops, which expires after 10 seconds. The notification won't be intrusive and will just play a sound.
This will also happen when the user turns OFF the screen to stop the script or when the screen turns OFF by itself after the system display timeout setting, which can happen if a script is stuck at some screen.

On Android 8+, you can configure notification audio, vibration and a few other parameters from the Android's notification settings for the app itself, so it saves a lot of work for me. The `Messages` channel is used for these notifications. If someone is annoyed by these notifications, they could even turn them OFF.

fixes #263 
@tchofy can you test the build from this PR?