### PR TITLE
Skill Spam

### DIFF
--- a/app/src/main/res/values-b+zh+TW/localized.xml
+++ b/app/src/main/res/values-b+zh+TW/localized.xml
@@ -126,7 +126,7 @@
     <string name="p_max_skill_3">三技滿</string>
 
     <string name="p_game_server">伺服器</string>
-    <string name="p_cast_np">自動寶具</string>
+    <string name="p_spam_np">自動寶具</string>
     <string name="p_auto_choose_target">自動選取敵人</string>
     <string name="p_story_skip">跳過劇情</string>
     <string name="p_skill_confirmation">技能確認</string>
@@ -194,9 +194,9 @@
     <string name="p_boost_item_disabled">關閉</string>
     <string name="p_boost_item_skip">跳過</string>
 
-    <string name="p_cast_np_none">無</string>
-    <string name="p_cast_np_spam">能放就放</string>
-    <string name="p_cast_np_danger">Danger 敵人時施放</string>
+    <string name="p_spam_none">無</string>
+    <string name="p_spam_spam">能放就放</string>
+    <string name="p_spam_danger">Danger 敵人時施放</string>
 
     <string name="p_support_mode_first">第一位支援</string>
     <string name="p_support_mode_manual">手動選擇</string>

--- a/app/src/main/res/values-ko/localized.xml
+++ b/app/src/main/res/values-ko/localized.xml
@@ -126,7 +126,7 @@
     <string name="p_max_skill_3">3 스킬 만렙</string>
 
     <string name="p_game_server">게임 서버</string>
-    <string name="p_cast_np">보구 사용</string>
+    <string name="p_spam_np">보구 사용</string>
     <string name="p_auto_choose_target">대상 자동 선택</string>
     <string name="p_story_skip">스토리 스킵</string>
     <string name="p_skill_confirmation">스킬 사용 확인</string>
@@ -195,9 +195,9 @@
     <string name="p_boost_item_disabled">비활성화</string>
     <string name="p_boost_item_skip">스킵</string>
 
-    <string name="p_cast_np_none">없음</string>
-    <string name="p_cast_np_spam">반복</string>
-    <string name="p_cast_np_danger">위험</string>
+    <string name="p_spam_none">없음</string>
+    <string name="p_spam_spam">반복</string>
+    <string name="p_spam_danger">위험</string>
 
     <string name="p_support_mode_first">첫번째</string>
     <string name="p_support_mode_manual">수동</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -43,13 +43,13 @@
         <item>3</item>
     </string-array>
 
-    <array name="battle_np_types_labels">
-        <item>@string/p_cast_np_none</item>
-        <item>@string/p_cast_np_spam</item>
-        <item>@string/p_cast_np_danger</item>
+    <array name="spam_types_labels">
+        <item>@string/p_spam_none</item>
+        <item>@string/p_spam_spam</item>
+        <item>@string/p_spam_danger</item>
     </array>
 
-    <array name="battle_np_types_values">
+    <array name="spam_types_values">
         <item>None</item>
         <item>Spam</item>
         <item>Danger</item>

--- a/app/src/main/res/values/localized.xml
+++ b/app/src/main/res/values/localized.xml
@@ -134,7 +134,8 @@
     <string name="p_max_skill_3">Max Skill 3</string>
 
     <string name="p_game_server">Game Server</string>
-    <string name="p_cast_np">Cast Noble Phantasm</string>
+    <string name="p_spam_np">NP Spam</string>
+    <string name="p_spam_skill">Skill Spam</string>
     <string name="p_auto_choose_target">Auto choose target</string>
     <string name="p_story_skip">Story Skip</string>
     <string name="p_skill_confirmation">Skill Confirmation</string>
@@ -206,9 +207,9 @@
     <string name="p_boost_item_disabled">Disabled</string>
     <string name="p_boost_item_skip">Skip</string>
 
-    <string name="p_cast_np_none">None</string>
-    <string name="p_cast_np_spam">Spam</string>
-    <string name="p_cast_np_danger">Danger</string>
+    <string name="p_spam_none">None</string>
+    <string name="p_spam_spam">Spam</string>
+    <string name="p_spam_danger">Danger</string>
 
     <string name="p_support_mode_first">First</string>
     <string name="p_support_mode_manual">Manual</string>

--- a/app/src/main/res/xml/app_preferences.xml
+++ b/app/src/main/res/xml/app_preferences.xml
@@ -45,11 +45,20 @@
 
         <ListPreference
             app:defaultValue="None"
-            app:entries="@array/battle_np_types_labels"
-            app:entryValues="@array/battle_np_types_values"
+            app:entries="@array/spam_types_labels"
+            app:entryValues="@array/spam_types_values"
             app:icon="@drawable/ic_star"
-            app:key="@string/pref_battle_np"
-            app:title="@string/p_cast_np"
+            app:key="@string/pref_spam_np"
+            app:title="@string/p_spam_np"
+            app:useSimpleSummaryProvider="true" />
+
+        <ListPreference
+            app:defaultValue="None"
+            app:entries="@array/spam_types_labels"
+            app:entryValues="@array/spam_types_values"
+            app:icon="@drawable/ic_wand"
+            app:key="@string/pref_spam_skill"
+            app:title="@string/p_spam_skill"
             app:useSimpleSummaryProvider="true" />
 
         <SwitchPreferenceCompat

--- a/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/Preferences.kt
+++ b/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/Preferences.kt
@@ -48,7 +48,9 @@ class PreferencesImpl @Inject constructor(
             selectedAutoSkillConfigKey = value.id
         }
 
-    override val castNoblePhantasm by prefs.castNoblePhantasm
+    override val npSpam by prefs.npSpam
+
+    override val skillSpam by prefs.skillSpam
 
     override val autoChooseTarget by prefs.autoChooseTarget
 

--- a/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/core/PrefsCore.kt
+++ b/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/core/PrefsCore.kt
@@ -2,9 +2,9 @@ package com.mathewsachin.fategrandautomata.prefs.core
 
 import com.mathewsachin.fategrandautomata.StorageDirs
 import com.mathewsachin.fategrandautomata.prefs.R
-import com.mathewsachin.fategrandautomata.scripts.enums.BattleNoblePhantasmEnum
 import com.mathewsachin.fategrandautomata.scripts.enums.GameServerEnum
 import com.mathewsachin.fategrandautomata.scripts.enums.ScriptModeEnum
+import com.mathewsachin.fategrandautomata.scripts.enums.SpamEnum
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -29,9 +29,14 @@ class PrefsCore @Inject constructor(
 
     val selectedAutoSkillConfig = maker.string(R.string.pref_autoskill_selected)
 
-    val castNoblePhantasm = maker.enum(
-        R.string.pref_battle_np,
-        BattleNoblePhantasmEnum.None
+    val npSpam = maker.enum(
+        R.string.pref_spam_np,
+        SpamEnum.None
+    )
+
+    val skillSpam = maker.enum(
+        R.string.pref_spam_skill,
+        SpamEnum.None
     )
 
     val autoChooseTarget = maker.bool(R.string.pref_auto_choose_target)

--- a/prefs/src/main/res/values/preferences.xml
+++ b/prefs/src/main/res/values/preferences.xml
@@ -4,7 +4,8 @@
     <string name="pref_skill_conf">skill_conf</string>
     <string name="pref_autoskill_selected">autoskill_selected</string>
     <string name="pref_card_priority">card_priority</string>
-    <string name="pref_battle_np">battle_np</string>
+    <string name="pref_spam_np">battle_np</string>
+    <string name="pref_spam_skill">skill_spam</string>
     <string name="pref_auto_choose_target">auto_choose_target</string>
     <string name="pref_story_skip">story_skip</string>
     <string name="pref_stop_on_ce_drop">stop_on_ce_drop</string>

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/enums/SpamEnum.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/enums/SpamEnum.kt
@@ -1,5 +1,5 @@
 package com.mathewsachin.fategrandautomata.scripts.enums
 
-enum class BattleNoblePhantasmEnum {
+enum class SpamEnum {
     None, Spam, Danger
 }

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/AutoSkill.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/AutoSkill.kt
@@ -3,9 +3,7 @@ package com.mathewsachin.fategrandautomata.scripts.modules
 import com.mathewsachin.fategrandautomata.scripts.IFgoAutomataApi
 import com.mathewsachin.fategrandautomata.scripts.models.*
 import com.mathewsachin.libautomata.IPattern
-import com.mathewsachin.libautomata.Location
 import com.mathewsachin.libautomata.Region
-import com.mathewsachin.libautomata.Size
 import kotlin.time.Duration
 import kotlin.time.seconds
 
@@ -45,7 +43,7 @@ class AutoSkill(fgAutomataApi: IFgoAutomataApi) : IFgoAutomataApi by fgAutomataA
     }
 
     private val Skill.imageRegion
-        get() = Region(clickLocation + Location(30, 30), Size(30, 30))
+        get() = Region(30, 30, 30, 30) + clickLocation
 
     fun castServantSkill(skill: Skill.Servant, target: ServantTarget?) {
         skillTable[skill]?.image?.close()

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/prefs/IPreferences.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/prefs/IPreferences.kt
@@ -1,8 +1,8 @@
 package com.mathewsachin.fategrandautomata.scripts.prefs
 
-import com.mathewsachin.fategrandautomata.scripts.enums.BattleNoblePhantasmEnum
 import com.mathewsachin.fategrandautomata.scripts.enums.GameServerEnum
 import com.mathewsachin.fategrandautomata.scripts.enums.ScriptModeEnum
+import com.mathewsachin.fategrandautomata.scripts.enums.SpamEnum
 import com.mathewsachin.libautomata.IPlatformPrefs
 import kotlin.time.Duration
 
@@ -13,7 +13,8 @@ interface IPreferences {
     val autoSkillList: Set<String>
     val autoSkillPreferences: List<IAutoSkillPreferences>
     var selectedAutoSkillConfig: IAutoSkillPreferences
-    val castNoblePhantasm: BattleNoblePhantasmEnum
+    val npSpam: SpamEnum
+    val skillSpam: SpamEnum
     val autoChooseTarget: Boolean
     val storySkip: Boolean
     val withdrawEnabled: Boolean


### PR DESCRIPTION
fixes #510 

- Renamed 'Cast Noble Phantasm' to 'Spam NP'
- Added 'Spam Skills' setting with None, Spam, Danger options

Remembers the skills you used in AutoSkill command along with targets.
When the AutoSkill command finishes, like NP spam, skill spam starts if enabled.
It uses the skills as soon as they come off cooldown. If a servant dies, the skill's image (unless the servant coming in has the same skill image) won't match and those skills won't be spammed.