### PR TITLE
Shuffle cards

### DIFF
--- a/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/BattleConfigItemSettingsFragment.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/BattleConfigItemSettingsFragment.kt
@@ -17,10 +17,7 @@ import com.google.gson.Gson
 import com.mathewsachin.fategrandautomata.R
 import com.mathewsachin.fategrandautomata.SupportImageKind
 import com.mathewsachin.fategrandautomata.prefs.core.PrefsCore
-import com.mathewsachin.fategrandautomata.scripts.enums.MaterialEnum
-import com.mathewsachin.fategrandautomata.scripts.enums.SpamEnum
-import com.mathewsachin.fategrandautomata.scripts.enums.SupportClass
-import com.mathewsachin.fategrandautomata.scripts.enums.SupportSelectionModeEnum
+import com.mathewsachin.fategrandautomata.scripts.enums.*
 import com.mathewsachin.fategrandautomata.scripts.prefs.IBattleConfig
 import com.mathewsachin.fategrandautomata.scripts.prefs.IPreferences
 import com.mathewsachin.fategrandautomata.util.*
@@ -158,6 +155,9 @@ class BattleConfigItemSettingsFragment : PreferenceFragmentCompat() {
             initWith<MaterialEnum> { it.stringRes }
             summaryProvider = MultiSelectSummaryProvider()
         }
+
+        findPreference<ListPreference>(getString(R.string.pref_shuffle_cards))
+            ?.initWith<ShuffleCardsEnum> { it.stringRes }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/util/LocalizationExtensions.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/util/LocalizationExtensions.kt
@@ -48,6 +48,13 @@ val SupportSelectionModeEnum.stringRes
         SupportSelectionModeEnum.Preferred -> R.string.p_support_mode_preferred
     }
 
+val ShuffleCardsEnum.stringRes
+    get() = when (this) {
+        ShuffleCardsEnum.None -> R.string.p_shuffle_cards_when_none
+        ShuffleCardsEnum.NoEffective -> R.string.p_shuffle_cards_when_no_effective
+        ShuffleCardsEnum.NoNPMatching -> R.string.p_shuffle_cards_when_no_np_matching
+    }
+
 val MaterialEnum.stringRes
     get() = when (this) {
         MaterialEnum.Proof -> R.string.mat_proof

--- a/app/src/main/res/values/localized.xml
+++ b/app/src/main/res/values/localized.xml
@@ -337,6 +337,10 @@
     <string name="mat_eternal_ice">Eternal Ice</string>
     <string name="mat_steel">Aurora Steel</string>
 
-    <string name="shuffle_cards">Shuffle cards</string>
-    <string name="shuffle_if_no_effective_cards_in_w_3">Shuffle if no effective cards in W3</string>
+    <string name="p_shuffle_cards">Shuffle cards</string>
+    <string name="p_shuffle_cards_wave">Wave</string>
+    <string name="p_shuffle_cards_when">When</string>
+    <string name="p_shuffle_cards_when_none">None</string>
+    <string name="p_shuffle_cards_when_no_effective">No effective cards</string>
+    <string name="p_shuffle_cards_when_no_np_matching">No cards matching NP</string>
 </resources>

--- a/app/src/main/res/values/localized.xml
+++ b/app/src/main/res/values/localized.xml
@@ -336,4 +336,7 @@
     <string name="mat_stinger">Deadly Poisonous Needle</string>
     <string name="mat_eternal_ice">Eternal Ice</string>
     <string name="mat_steel">Aurora Steel</string>
+
+    <string name="shuffle_cards">Shuffle cards</string>
+    <string name="shuffle_if_no_effective_cards_in_w_3">Shuffle if no effective cards in W3</string>
 </resources>

--- a/app/src/main/res/xml/battle_config_preferences.xml
+++ b/app/src/main/res/xml/battle_config_preferences.xml
@@ -33,12 +33,6 @@
         app:key="@string/pref_card_priority"
         app:title="@string/p_battle_config_card_priority" />
 
-    <SwitchPreferenceCompat
-        app:icon="@drawable/ic_refresh"
-        app:key="@string/pref_shuffle_if_no_effective_cards_in_w_3"
-        app:title="@string/shuffle_cards"
-        app:summary="@string/shuffle_if_no_effective_cards_in_w_3" />
-
     <MultiSelectListPreference
         app:icon="@drawable/ic_fang"
         app:key="@string/pref_battle_config_mat"
@@ -101,6 +95,26 @@
             app:icon="@drawable/ic_wand"
             app:key="@string/pref_spam_skill"
             app:title="@string/p_spam_skill"
+            app:useSimpleSummaryProvider="true" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        app:key="shuffle_category"
+        app:title="@string/p_shuffle_cards">
+        <SeekBarPreference
+            app:defaultValue="3"
+            app:min="1"
+            android:max="3"
+            app:showSeekBarValue="true"
+            app:icon="@drawable/ic_counter"
+            app:key="@string/pref_shuffle_cards_wave"
+            app:title="@string/p_shuffle_cards_wave" />
+
+        <ListPreference
+            app:defaultValue="None"
+            app:icon="@drawable/ic_refresh"
+            app:key="@string/pref_shuffle_cards"
+            app:title="@string/p_shuffle_cards_when"
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/main/res/xml/battle_config_preferences.xml
+++ b/app/src/main/res/xml/battle_config_preferences.xml
@@ -33,6 +33,12 @@
         app:key="@string/pref_card_priority"
         app:title="@string/p_battle_config_card_priority" />
 
+    <SwitchPreferenceCompat
+        app:icon="@drawable/ic_refresh"
+        app:key="@string/pref_shuffle_if_no_effective_cards_in_w_3"
+        app:title="@string/shuffle_cards"
+        app:summary="@string/shuffle_if_no_effective_cards_in_w_3" />
+
     <MultiSelectListPreference
         app:icon="@drawable/ic_fang"
         app:key="@string/pref_battle_config_mat"

--- a/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/BattleConfig.kt
+++ b/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/BattleConfig.kt
@@ -36,7 +36,9 @@ internal class BattleConfig(
         }
     }
 
-    override val shuffleIfNoEffectiveCardsInW3 by prefs.shuffleIfNoEffectiveCardsInW3
+    override val shuffleCards by prefs.shuffleCards
+
+    override val shuffleCardsWave by prefs.shuffleCardsWave
 
     override val support = SupportPreferences(prefs.support)
 

--- a/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/BattleConfig.kt
+++ b/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/BattleConfig.kt
@@ -36,6 +36,8 @@ internal class BattleConfig(
         }
     }
 
+    override val shuffleIfNoEffectiveCardsInW3 by prefs.shuffleIfNoEffectiveCardsInW3
+
     override val support = SupportPreferences(prefs.support)
 
     override val npSpam by prefs.npSpam

--- a/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/core/BattleConfigCore.kt
+++ b/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/core/BattleConfigCore.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import com.mathewsachin.fategrandautomata.prefs.R
 import com.mathewsachin.fategrandautomata.prefs.defaultCardPriority
 import com.mathewsachin.fategrandautomata.scripts.enums.BraveChainEnum
+import com.mathewsachin.fategrandautomata.scripts.enums.ShuffleCardsEnum
 import com.mathewsachin.fategrandautomata.scripts.enums.SpamEnum
 
 class BattleConfigCore(
@@ -49,7 +50,8 @@ class BattleConfigCore(
             it.joinToString(",") { m -> m.toString() }
         })
 
-    val shuffleIfNoEffectiveCardsInW3 = maker.bool(R.string.pref_shuffle_if_no_effective_cards_in_w_3)
+    val shuffleCards = maker.enum(R.string.pref_shuffle_cards, ShuffleCardsEnum.None)
+    val shuffleCardsWave = maker.int(R.string.pref_shuffle_cards_wave, 3)
 
     val party = maker.stringAsInt(R.string.pref_battle_config_party, -1)
 

--- a/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/core/BattleConfigCore.kt
+++ b/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/core/BattleConfigCore.kt
@@ -49,6 +49,8 @@ class BattleConfigCore(
             it.joinToString(",") { m -> m.toString() }
         })
 
+    val shuffleIfNoEffectiveCardsInW3 = maker.bool(R.string.pref_shuffle_if_no_effective_cards_in_w_3)
+
     val party = maker.stringAsInt(R.string.pref_battle_config_party, -1)
 
     val materials = maker.stringSet(R.string.pref_battle_config_mat)

--- a/prefs/src/main/res/values/preferences.xml
+++ b/prefs/src/main/res/values/preferences.xml
@@ -94,5 +94,6 @@
     <string name="pref_nav_update">nav_update</string>
     <string name="pref_nav_preferred_support">nav_preferred_support</string>
 
-    <string name="pref_shuffle_if_no_effective_cards_in_w_3">shuffle_if_no_effective_cards_in_w_3</string>
+    <string name="pref_shuffle_cards">shuffle_cards</string>
+    <string name="pref_shuffle_cards_wave">shuffle_cards_wave</string>
 </resources>

--- a/prefs/src/main/res/values/preferences.xml
+++ b/prefs/src/main/res/values/preferences.xml
@@ -93,4 +93,6 @@
     <string name="pref_nav_fine_tune">nav_fine_tune</string>
     <string name="pref_nav_update">nav_update</string>
     <string name="pref_nav_preferred_support">nav_preferred_support</string>
+
+    <string name="pref_shuffle_if_no_effective_cards_in_w_3">shuffle_if_no_effective_cards_in_w_3</string>
 </resources>

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/enums/ShuffleCardsEnum.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/enums/ShuffleCardsEnum.kt
@@ -1,0 +1,7 @@
+package com.mathewsachin.fategrandautomata.scripts.enums
+
+enum class ShuffleCardsEnum {
+    None,
+    NoEffective,
+    NoNPMatching
+}

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/models/battle/BattleState.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/models/battle/BattleState.kt
@@ -66,6 +66,12 @@ class BattleState {
             runState.stageState.stageCountSnaphot = value
         }
 
+    var shuffled
+        get() = runState.shuffled
+        set(value) {
+            runState.shuffled = value
+        }
+
     val stage get() = runState.stage
     val turn get() = runState.turn
 

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/models/battle/RunState.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/models/battle/RunState.kt
@@ -36,4 +36,6 @@ class RunState {
     fun nextStage() = ++stage
 
     fun nextTurn() = ++turn
+
+    var shuffled = false
 }

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/AutoSkill.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/AutoSkill.kt
@@ -75,7 +75,7 @@ class AutoSkill(fgAutomataApi: IFgoAutomataApi) : IFgoAutomataApi by fgAutomataA
         0.5.seconds.wait()
     }
 
-    private fun castMasterSkill(skill: Skill.Master, target: ServantTarget?) {
+    fun castMasterSkill(skill: Skill.Master, target: ServantTarget? = null) {
         openMasterSkillMenu()
 
         castSkill(skill, target)

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Battle.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Battle.kt
@@ -37,7 +37,7 @@ class Battle(fgAutomataApi: IFgoAutomataApi) : IFgoAutomataApi by fgAutomataApi 
 
     fun isIdle() = images.battle in Game.battleScreenRegion
 
-    private fun clickAttack() {
+    fun clickAttack() {
         if (state.hasClickedAttack) {
             return
         }

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Card.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Card.kt
@@ -5,10 +5,7 @@ import com.mathewsachin.fategrandautomata.scripts.enums.BraveChainEnum
 import com.mathewsachin.fategrandautomata.scripts.enums.CardAffinityEnum
 import com.mathewsachin.fategrandautomata.scripts.enums.CardTypeEnum
 import com.mathewsachin.fategrandautomata.scripts.enums.SpamEnum
-import com.mathewsachin.fategrandautomata.scripts.models.AutoSkillAction
-import com.mathewsachin.fategrandautomata.scripts.models.CardPriorityPerWave
-import com.mathewsachin.fategrandautomata.scripts.models.CardScore
-import com.mathewsachin.fategrandautomata.scripts.models.CommandCard
+import com.mathewsachin.fategrandautomata.scripts.models.*
 import timber.log.Timber
 import timber.log.debug
 import java.util.*
@@ -263,7 +260,36 @@ class Card(fgAutomataApi: IFgoAutomataApi) : IFgoAutomataApi by fgAutomataApi {
         return cards
     }
 
+    private fun shouldShuffle(): Boolean {
+        if (battle.state.stage == 2 && !battle.state.shuffled) {
+            val effectiveCardCount = commandCards
+                .filterKeys { it.CardAffinity == CardAffinityEnum.Weak }
+                .map { it.value.size }
+                .sum()
+
+            return effectiveCardCount == 0
+        }
+
+        return false
+    }
+
+    private fun shuffleCards() {
+        if (shouldShuffle()) {
+            Game.battleBack.click()
+
+            autoSkill.castMasterSkill(Skill.Master.list[2])
+
+            battle.state.hasClickedAttack = false
+
+            battle.clickAttack()
+
+            battle.state.shuffled = true
+        }
+    }
+
     fun clickCommandCards() {
+        shuffleCards()
+
         val cards = pickCards()
 
         if (atk.cardsBeforeNP > 0) {

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Game.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Game.kt
@@ -93,6 +93,8 @@ class Game @Inject constructor(val prefs: IPreferences) {
         val battleMasterSkillOpenClick = Location(2380, 640)
         val battleOrderChangeOkClick = Location(1280, 1260)
 
+        val battleBack = Location(2400, 1370)
+
         val resultScreenRegion = Region(100, 300, 700, 200)
         val resultBondRegion = Region(2000, 750, 120, 190)
         val resultMasterExpRegion = Region(1280, 350, 400, 110)

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/prefs/IBattleConfig.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/prefs/IBattleConfig.kt
@@ -14,6 +14,7 @@ interface IBattleConfig {
     val party: Int
     val materials: List<MaterialEnum>
     val support: ISupportPreferences
+    val shuffleIfNoEffectiveCardsInW3: Boolean
 
     val npSpam: SpamEnum
     val skillSpam: SpamEnum

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/prefs/IBattleConfig.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/prefs/IBattleConfig.kt
@@ -2,6 +2,7 @@ package com.mathewsachin.fategrandautomata.scripts.prefs
 
 import com.mathewsachin.fategrandautomata.scripts.enums.BraveChainEnum
 import com.mathewsachin.fategrandautomata.scripts.enums.MaterialEnum
+import com.mathewsachin.fategrandautomata.scripts.enums.ShuffleCardsEnum
 import com.mathewsachin.fategrandautomata.scripts.enums.SpamEnum
 
 interface IBattleConfig {
@@ -14,7 +15,8 @@ interface IBattleConfig {
     val party: Int
     val materials: List<MaterialEnum>
     val support: ISupportPreferences
-    val shuffleIfNoEffectiveCardsInW3: Boolean
+    val shuffleCards: ShuffleCardsEnum
+    val shuffleCardsWave: Int
 
     val npSpam: SpamEnum
     val skillSpam: SpamEnum


### PR DESCRIPTION
Added an option to shuffle cards using Mages Association to Battle Configs which is configurable to happen in any of the following cases:
1. When there's no effective card
2. When there's no card matching the NP'ing servant

There's also a Wave setting to set which wave you want the shuffle to happen. Ranges from 1-3 only.