### PR TITLE
Repeat quest with Boost items

### DIFF
--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoBattle.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoBattle.kt
@@ -306,9 +306,23 @@ open class AutoBattle @Inject constructor(
         // Needed to show we don't need to enter the "StartQuest" function
         isContinuing = true
 
-        // Pressing Continue option after completing a quest, reseting the state as would occur in "Menu" function
+        // Pressing Continue option after completing a quest, resetting the state as would occur in "Menu" function
         battle.resetState()
-        Game.continueClick.click()
+
+        val region = Game.continueRegion.find(images.confirm)?.Region
+            ?: return
+
+        // If Boost items are usable, Continue button shifts to the right
+        val useBoost = if (region.X > 1630) {
+            val boost = BoostItem.of(prefs.boostItemSelectionMode)
+
+            boost is BoostItem.Enabled && boost != BoostItem.Enabled.Skip
+        } else false
+
+        if (useBoost) {
+            Game.continueBoostClick.click()
+            useBoostItem()
+        } else Game.continueClick.click()
 
         showRefillsAndRunsMessage()
 
@@ -502,6 +516,10 @@ open class AutoBattle @Inject constructor(
 
         2.seconds.wait()
 
+        useBoostItem()
+    }
+
+    private fun useBoostItem() {
         val boostItem = BoostItem.of(prefs.boostItemSelectionMode)
         if (boostItem is BoostItem.Enabled) {
             boostItem.clickLocation.click()

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Game.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Game.kt
@@ -27,11 +27,12 @@ class Game @Inject constructor(val prefs: IPreferences) {
         val scriptRegion = Region(Location(), scriptSize)
 
         val menuScreenRegion = Region(2100, 1200, 1000, 1000)
-        val continueRegion = Region(1400, 1000, 600, 200)
+        val continueRegion = Region(1400, 1000, 800, 200)
         val menuStorySkipRegion = Region(2240, 20, 300, 120)
 
         val menuSelectQuestClick = Location(2290, 440)
         val menuStartQuestClick = Location(2400, 1350)
+        val continueBoostClick = Location(1260, 1120)
         val continueClick = Location(1650, 1120)
         val menuStorySkipClick = Location(2360, 80)
         val menuStorySkipYesClick = Location(1600, 1100)


### PR DESCRIPTION
fixes #556 

Uses the existing `Boost Item` setting in `More options`.
Only 1-3 boosters can be used. It won't scroll down and use other boosters.
It'll skip through if you haven't set the `Boost Item` setting.

Boost Confirmation still has to be OFF in FGO.